### PR TITLE
Move milei_happened_globvar initialization to event trigger

### DIFF
--- a/common/character_templates/mym_character_templates.txt
+++ b/common/character_templates/mym_character_templates.txt
@@ -96,7 +96,4 @@ milei_character_template = {
 		ambitious
 		persistent
 	}
-	on_created = {
-		set_global_variable = milei_happened_globvar
-	}
 }

--- a/events/character_events/mym_milei_events.txt
+++ b/events/character_events/mym_milei_events.txt
@@ -40,6 +40,7 @@ milei.1 = {
 	}
 
 	immediate = {
+		set_global_variable = milei_happened_globvar
 	}
 
 	option = {


### PR DESCRIPTION
## Summary
Refactored the initialization of the `milei_happened_globvar` global variable from the character template's `on_created` callback to the `immediate` block of the Milei event trigger.

## Key Changes
- Removed the `on_created` event handler from the `milei_character_template` that was setting the global variable upon character creation
- Moved the `set_global_variable = milei_happened_globvar` call to the `immediate` block of the `milei.1` event, ensuring the variable is set when the event is triggered rather than when the character is created

## Implementation Details
This change decouples the global variable initialization from character creation, making it event-driven instead. This approach ensures the variable is only set when the specific Milei event actually fires, providing better control over when this state is established in the game flow.

https://claude.ai/code/session_01YZMbEbMRhiPPDP9mrkBqgr