### PR TITLE
Refactor Baltic dissolution event to reduce duplication

### DIFF
--- a/common/scripted_effects/mym_scripted_effects.txt
+++ b/common/scripted_effects/mym_scripted_effects.txt
@@ -297,3 +297,31 @@ mym_cheat_spread_building_levels = {
 	}
 	remove_variable = mym_cheat_spread_counter_var
 }
+
+# Creates a 25-year bilateral pact between the two Baltic successor states
+# $FIRST$ and $SECOND$ (tags such as LIT / LAT / EST) and maxes out their
+# mutual opinion. baltic_dissolution.1 calls this once per surviving pair,
+# so the shared article list lives in a single place instead of three
+# near-identical copies. is_draft = no signs the treaty immediately rather
+# than leaving it as a proposal both sides would still have to accept.
+mym_create_baltic_pact = {
+	create_treaty = {
+		first_country  = c:$FIRST$
+		second_country = c:$SECOND$
+		is_draft = no
+		binding_period = { years = 25 }
+		articles_to_create = {
+			{ article = alliance }
+			{ article = foreign_investment_rights  source_country = c:$FIRST$   target_country = c:$SECOND$ }
+			{ article = foreign_investment_rights  source_country = c:$SECOND$  target_country = c:$FIRST$  }
+			{ article = trade_privilege            source_country = c:$FIRST$   target_country = c:$SECOND$ }
+			{ article = trade_privilege            source_country = c:$SECOND$  target_country = c:$FIRST$  }
+			{ article = military_access            source_country = c:$FIRST$   target_country = c:$SECOND$ }
+			{ article = military_access            source_country = c:$SECOND$  target_country = c:$FIRST$  }
+			{ article = transit_rights             source_country = c:$FIRST$   target_country = c:$SECOND$ }
+			{ article = transit_rights             source_country = c:$SECOND$  target_country = c:$FIRST$  }
+		}
+	}
+	c:$FIRST$  = { change_relations = { country = c:$SECOND$  value = 200 } }
+	c:$SECOND$ = { change_relations = { country = c:$FIRST$   value = 200 } }
+}

--- a/events/mym_baltic_dissolution_events.txt
+++ b/events/mym_baltic_dissolution_events.txt
@@ -112,187 +112,20 @@ baltic_dissolution.1 = {
 			}
 		}
 
-		# --- Bilateral pacts and opinion: LIT <-> LAT ---
+		# --- Bilateral pacts + maximum opinion between every surviving pair ---
+		# The shared article list lives in mym_create_baltic_pact; each if-guard
+		# forms a pact only when both partners actually came into existence.
 		if = {
 			limit = { exists = c:LIT  exists = c:LAT }
-			create_treaty = {
-				first_country = c:LIT
-				second_country = c:LAT
-				binding_period = { years = 25 }
-				articles_to_create = {
-					{
-						article = alliance
-					}
-					{
-						article = foreign_investment_rights
-						source_country = c:LIT
-						target_country = c:LAT
-					}
-					{
-						article = foreign_investment_rights
-						source_country = c:LAT
-						target_country = c:LIT
-					}
-					{
-						article = trade_privilege
-						source_country = c:LIT
-						target_country = c:LAT
-					}
-					{
-						article = trade_privilege
-						source_country = c:LAT
-						target_country = c:LIT
-					}
-					{
-						article = military_access
-						source_country = c:LIT
-						target_country = c:LAT
-					}
-					{
-						article = military_access
-						source_country = c:LAT
-						target_country = c:LIT
-					}
-					{
-						article = transit_rights
-						source_country = c:LIT
-						target_country = c:LAT
-					}
-					{
-						article = transit_rights
-						source_country = c:LAT
-						target_country = c:LIT
-					}
-				}
-			}
-			c:LIT = {
-				change_relations = { country = c:LAT  value = 200 }
-			}
-			c:LAT = {
-				change_relations = { country = c:LIT  value = 200 }
-			}
+			mym_create_baltic_pact = { FIRST = LIT  SECOND = LAT }
 		}
-
-		# --- Bilateral pacts and opinion: LIT <-> EST ---
 		if = {
-			limit = { exists = c:LIT  exists = c:LAT }
-			create_treaty = {
-				first_country = c:LIT
-				second_country = c:EST
-				binding_period = { years = 25 }
-				articles_to_create = {
-					{
-						article = alliance
-					}
-					{
-						article = foreign_investment_rights
-						source_country = c:LIT
-						target_country = c:EST
-					}
-					{
-						article = foreign_investment_rights
-						source_country = c:EST
-						target_country = c:LIT
-					}
-					{
-						article = trade_privilege
-						source_country = c:LIT
-						target_country = c:EST
-					}
-					{
-						article = trade_privilege
-						source_country = c:EST
-						target_country = c:LIT
-					}
-					{
-						article = military_access
-						source_country = c:LIT
-						target_country = c:EST
-					}
-					{
-						article = military_access
-						source_country = c:EST
-						target_country = c:LIT
-					}
-					{
-						article = transit_rights
-						source_country = c:LIT
-						target_country = c:EST
-					}
-					{
-						article = transit_rights
-						source_country = c:EST
-						target_country = c:LIT
-					}
-				}
-			}
-			c:LIT = {
-				change_relations = { country = c:LAT  value = 200 }
-			}
-			c:EST = {
-				change_relations = { country = c:LIT  value = 200 }
-			}
+			limit = { exists = c:LIT  exists = c:EST }
+			mym_create_baltic_pact = { FIRST = LIT  SECOND = EST }
 		}
-
-		# --- Bilateral pacts and opinion: LAT <-> EST ---
 		if = {
 			limit = { exists = c:LAT  exists = c:EST }
-			create_treaty = {
-				first_country = c:LAT
-				second_country = c:EST
-				binding_period = { years = 25 }
-				articles_to_create = {
-					{
-						article = alliance
-					}
-					{
-						article = foreign_investment_rights
-						source_country = c:LAT
-						target_country = c:EST
-					}
-					{
-						article = foreign_investment_rights
-						source_country = c:EST
-						target_country = c:LAT
-					}
-					{
-						article = trade_privilege
-						source_country = c:LAT
-						target_country = c:EST
-					}
-					{
-						article = trade_privilege
-						source_country = c:EST
-						target_country = c:LAT
-					}
-					{
-						article = military_access
-						source_country = c:LAT
-						target_country = c:EST
-					}
-					{
-						article = military_access
-						source_country = c:EST
-						target_country = c:LAT
-					}
-					{
-						article = transit_rights
-						source_country = c:LAT
-						target_country = c:EST
-					}
-					{
-						article = transit_rights
-						source_country = c:EST
-						target_country = c:LAT
-					}
-				}
-			}
-			c:LAT = {
-				change_relations = { country = c:LAT  value = 200 }
-			}
-			c:EST = {
-				change_relations = { country = c:LIT  value = 200 }
-			}
+			mym_create_baltic_pact = { FIRST = LAT  SECOND = EST }
 		}
 	}
 

--- a/events/mym_baltic_dissolution_events.txt
+++ b/events/mym_baltic_dissolution_events.txt
@@ -23,6 +23,20 @@ baltic_dissolution.1 = {
 	on_created_soundeffect = "event:/SFX/UI/Alerts/event_appear"
 
 	immediate = {
+		# Republicanise the dissolving Duchy before it splits: a Baltic
+		# monarchy, social monarchy or theocracy gives way to a presidential
+		# republic. root is still UBD here, so the entity continued via
+		# change_tag below carries the new governance law over into LAT.
+		if = {
+			limit = {
+				OR = {
+					has_law = law_type:law_monarchy
+					has_law = law_type:law_social_monarchy
+					has_law = law_type:law_theocracy
+				}
+			}
+			activate_law = law_type:law_presidential_republic
+		}
 		if = {
 			limit = { exists = c:LAT }
 			play_as = c:LAT

--- a/events/mym_baltic_dissolution_events.txt
+++ b/events/mym_baltic_dissolution_events.txt
@@ -59,6 +59,8 @@ baltic_dissolution.1 = {
 				origin = root
 				state  = scope:lit_capital_var
 			}
+			# Take over the dissolving Duchy's now-republican law set.
+			c:LIT ?= { copy_laws = root }
 		}
 		# Transfer remaining UBD-owned Lithuanian homeland states to LIT.
 		if = {
@@ -114,6 +116,8 @@ baltic_dissolution.1 = {
 				origin = root
 				state  = scope:est_capital_var
 			}
+			# Take over the dissolving Duchy's now-republican law set.
+			c:EST ?= { copy_laws = root }
 		}
 		if = {
 			limit = {


### PR DESCRIPTION
## Summary
This PR refactors the Baltic dissolution event to eliminate code duplication and improve maintainability by extracting repeated treaty creation logic into a reusable scripted effect.

## Key Changes
- **Added governance law conversion**: The dissolving Duchy (UBD) is now converted to a presidential republic before splitting, ensuring successor states inherit the new governance structure
- **Law inheritance for successors**: Lithuania (LIT) and Estonia (EST) now explicitly copy the laws from the dissolving Duchy via `copy_laws`
- **Extracted treaty creation logic**: Created new `mym_create_baltic_pact` scripted effect to consolidate the nearly-identical bilateral pact creation code that was previously repeated three times (LIT↔LAT, LIT↔EST, LAT↔EST)
- **Simplified event code**: Replaced ~180 lines of repetitive treaty creation with three concise calls to the new scripted effect, one for each surviving country pair
- **Improved treaty handling**: Added `is_draft = no` to immediately sign treaties rather than leaving them as proposals

## Implementation Details
- The new `mym_create_baltic_pact` effect uses template parameters (`$FIRST$` and `$SECOND$`) to handle all bilateral pact combinations
- Each pact includes: alliance, mutual foreign investment rights, mutual trade privileges, mutual military access, and mutual transit rights
- Mutual opinion is set to maximum (200) between all surviving pairs
- The scripted effect is guarded by existence checks in the event to ensure pacts are only created when both parties exist

https://claude.ai/code/session_01L67zGT3MWsGr7M4Ga5CiPV