### PR TITLE
Incorporate the Baltic successor nations' states

### DIFF
--- a/events/mym_baltic_dissolution_events.txt
+++ b/events/mym_baltic_dissolution_events.txt
@@ -130,6 +130,12 @@ baltic_dissolution.1 = {
 			}
 		}
 
+		# Incorporate every state the successor nations hold — states gained via
+		# create_country / set_state_owner are not incorporated by default.
+		c:LIT ?= { every_scope_state = { set_state_type = incorporated } }
+		c:LAT ?= { every_scope_state = { set_state_type = incorporated } }
+		c:EST ?= { every_scope_state = { set_state_type = incorporated } }
+
 		# --- Bilateral pacts + maximum opinion between every surviving pair ---
 		# The shared article list lives in mym_create_baltic_pact; each if-guard
 		# forms a pact only when both partners actually came into existence.


### PR DESCRIPTION
## Summary
Follow-up to the now-merged #41. After the Baltic dissolution assigns the homeland states to the successor nations, this makes sure those states are actually incorporated.

## Change
States obtained via `create_country` (the capital state) and `set_state_owner` (the transferred homelands) default to **unincorporated**, which would leave the freshly formed Baltic republics with colonial-style territory. After all homeland states are assigned — and before the bilateral pacts are formed — the event now sweeps every state owned by LIT, LAT and EST and sets its state type to `incorporated`:

```
c:LIT ?= { every_scope_state = { set_state_type = incorporated } }
c:LAT ?= { every_scope_state = { set_state_type = incorporated } }
c:EST ?= { every_scope_state = { set_state_type = incorporated } }
```

`set_state_type = incorporated` is the vanilla state-scope effect (same `set_state_owner` → `set_state_type` pattern as the EP1 Kazakh events). `every_scope_state` in a country scope iterates that country's owned states; `?=` guards against a nation that was never created.

## Note
For LAT (the former UBD, continued via `change_tag`) this incorporates all of its owned states, including any non-Baltic territory it held. In the typical UBD scenario that's fine; if only homeland states should be incorporated, a `limit = { state_region = { is_homeland = ... } }` can be added.

https://claude.ai/code/session_01L67zGT3MWsGr7M4Ga5CiPV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L67zGT3MWsGr7M4Ga5CiPV)_