### PR TITLE
Fix Baltic dissolution event culture handling and play_as logic

### DIFF
--- a/events/mym_baltic_dissolution_events.txt
+++ b/events/mym_baltic_dissolution_events.txt
@@ -136,6 +136,21 @@ baltic_dissolution.1 = {
 		c:LAT ?= { every_scope_state = { set_state_type = incorporated } }
 		c:EST ?= { every_scope_state = { set_state_type = incorporated } }
 
+		# LAT continued from the dissolving Duchy via change_tag and so still
+		# carries UBD's primary cultures. Drop every primary culture that isn't
+		# part of Latvia's own country definition, then guarantee Latvian is
+		# primary. Done here in immediate so it always runs, regardless of which
+		# successor the player continues as in the options below.
+		c:LAT ?= {
+			every_primary_culture = {
+				limit = {
+					NOT = { prev = { country_definition_has_culture = prev } }
+				}
+				prev = { remove_primary_culture = prev }
+			}
+			add_primary_culture = cu:latvian
+		}
+
 		# --- Bilateral pacts + maximum opinion between every surviving pair ---
 		# The shared article list lives in mym_create_baltic_pact; each if-guard
 		# forms a pact only when both partners actually came into existence.
@@ -159,12 +174,7 @@ baltic_dissolution.1 = {
 		trigger = {
 			exists = c:LIT
 		}
-		if = {
-			limit = {
-				NOT = { c:LIT = this }
-			}
-			play_as = c:LIT
-		}
+		play_as = c:LIT
 	}
 
 	option = {
@@ -172,12 +182,7 @@ baltic_dissolution.1 = {
 		trigger = {
 			exists = c:LAT
 		}
-		if = {
-			limit = {
-				NOT = { c:LAT = this }
-			}
-			play_as = c:LAT
-		}
+		play_as = c:LAT
 	}
 
 	option = {
@@ -185,23 +190,6 @@ baltic_dissolution.1 = {
 		trigger = {
 			exists = c:EST
 		}
-		if = {
-			limit = {
-				NOT = { c:EST = this }
-			}
-			play_as = c:EST
-		}
-	}
-
-	after = {
-		c:LAT = {
-			every_primary_culture = {
-				limit = {
-					NOT = { prev = { country_definition_has_culture = prev } }
-				}
-				prev = { remove_primary_culture = prev }
-			}
-			add_primary_culture = cu:latvian
-		}
+		play_as = c:EST
 	}
 }


### PR DESCRIPTION
## Summary
Refactored the Baltic dissolution event to fix culture management for Latvia and simplify the play_as option logic. The primary culture cleanup for Latvia is now executed in the immediate block to ensure it always runs, regardless of which successor state the player chooses.

## Key Changes
- **Moved culture cleanup to immediate block**: Latvia's primary culture management (removing non-Latvian cultures inherited from the Duchy and ensuring Latvian is primary) now executes in the immediate section rather than the after block. This guarantees the cleanup happens before any player choice, preventing inconsistent state.
- **Simplified play_as conditionals**: Removed unnecessary `if` statements that checked whether the player was already playing as the target country before calling `play_as`. The `play_as` command now executes unconditionally for each option, which is the correct behavior.
- **Removed after block**: The entire `after` block containing the culture cleanup logic has been removed since this logic is now in the immediate block.

## Implementation Details
The culture cleanup logic uses a filter to identify primary cultures that don't belong to Latvia's country definition, removes them, and then explicitly adds Latvian as a primary culture. By moving this to the immediate block, it executes once during event processing rather than potentially being skipped or executed conditionally based on player choice.

https://claude.ai/code/session_01RKxLywZBp3f9saPWMhHHv9