### PR TITLE
Add 3 month duration to An Encounter of the Constant Kind event

### DIFF
--- a/events/mym_heads_or_tails_events.txt
+++ b/events/mym_heads_or_tails_events.txt
@@ -12,6 +12,8 @@ heads_or_tails.1 = {
 		texture = gfx/event_pictures/heads_or_tails_1.dds
 	}
 
+	duration = 3
+
 	trigger = {
 		is_player = yes
 		NOT = {


### PR DESCRIPTION
Adds `duration = 3` to the `heads_or_tails.1` event ("An Encounter of the Constant Kind"), so the event stays open for 3 months before auto-resolving. Placement and syntax follow the vanilla event convention (e.g. `commander_events.txt`).

https://claude.ai/code/session_012BaeJqrMZeoCVGikn18JRt

---
_Generated by [Claude Code](https://claude.ai/code/session_012BaeJqrMZeoCVGikn18JRt)_