### PR TITLE
Add No Assimilation modifier for multicultural countries

### DIFF
--- a/common/on_actions/mym_on_actions.txt
+++ b/common/on_actions/mym_on_actions.txt
@@ -74,6 +74,11 @@ on_game_started_after_lobby = {
 		# Seed the cached heritage stats once so the JE has something to show before
 		# the first monthly pulse fires.
 		mym_refresh_global_religion_stats = yes
+		# Apply the no-assimilation modifier to countries that start multicultural,
+		# instead of waiting for the first monthly pulse.
+		every_country = {
+			mym_sync_no_assimilation_modifier = yes
+		}
 	}
 }
 
@@ -87,6 +92,18 @@ on_country_formed = {
 			add_journal_entry = {
 				type = je_mym_global_religion_tracker
 			}
+		}
+		mym_sync_no_assimilation_modifier = yes
+	}
+}
+
+# Sync the no-assimilation modifier the moment any law comes into force
+# (enacted, imposed or switched to a variant), instead of waiting for the
+# monthly pulse. Scope is the law; owner is the country.
+on_law_activated = {
+	effect = {
+		owner = {
+			mym_sync_no_assimilation_modifier = yes
 		}
 	}
 }

--- a/common/on_actions/mym_on_actions.txt
+++ b/common/on_actions/mym_on_actions.txt
@@ -20,6 +20,7 @@ on_monthly_pulse_country_mym_character_events = {
 on_monthly_pulse_country_mym_events = {
 	events = {
 		anarchist_balkanisation.1
+		no_assimilation.1
 	}
 	effect = {
 		# Keep modifier_has_unhealthy_economy in sync with the economy flag.

--- a/common/scripted_effects/mym_scripted_effects.txt
+++ b/common/scripted_effects/mym_scripted_effects.txt
@@ -325,3 +325,22 @@ mym_create_baltic_pact = {
 	c:$FIRST$  = { change_relations = { country = c:$SECOND$  value = 200 } }
 	c:$SECOND$ = { change_relations = { country = c:$FIRST$   value = 200 } }
 }
+
+# Keeps modifier_no_assimilation in sync with the citizenship law.
+# Idempotent and safe to call from any country scope at any time.
+mym_sync_no_assimilation_modifier = {
+	if = {
+		limit = {
+			has_law_or_variant = law_type:law_multicultural
+			NOT = { has_modifier = modifier_no_assimilation }
+		}
+		add_modifier = modifier_no_assimilation
+	}
+	else_if = {
+		limit = {
+			NOT = { has_law_or_variant = law_type:law_multicultural }
+			has_modifier = modifier_no_assimilation
+		}
+		remove_modifier = modifier_no_assimilation
+	}
+}

--- a/common/static_modifiers/mym_static_modifiers.txt
+++ b/common/static_modifiers/mym_static_modifiers.txt
@@ -11,3 +11,8 @@ modifier_miskatonic_acquisition = {
     country_prestige_add = 10
     interest_group_ig_intelligentsia_approval_add = 1
 }
+
+modifier_no_assimilation = {
+    icon = gfx/interface/icons/timed_modifier_icons/modifier_fist_positive.dds
+    state_assimilation_mult = -1.0
+}

--- a/common/static_modifiers/mym_static_modifiers.txt
+++ b/common/static_modifiers/mym_static_modifiers.txt
@@ -14,5 +14,6 @@ modifier_miskatonic_acquisition = {
 
 modifier_no_assimilation = {
     icon = gfx/interface/icons/timed_modifier_icons/modifier_fist_positive.dds
-    state_assimilation_mult = -1.0
+    # law_multicultural already grants -0.25, so the nationwide total is exactly -100%.
+    state_assimilation_mult = -0.75
 }

--- a/events/mym_no_assimilation_events.txt
+++ b/events/mym_no_assimilation_events.txt
@@ -1,7 +1,9 @@
 namespace = no_assimilation
 
-# Keeps modifier_no_assimilation in sync with the citizenship law:
-# Multicultural countries do not assimilate their pops at all.
+# Monthly safety net that keeps modifier_no_assimilation in sync with the
+# citizenship law: multicultural countries do not assimilate their pops.
+# The primary sync happens instantly via on_law_activated; this event only
+# fires when the modifier somehow drifted out of sync anyway.
 no_assimilation.1 = {
 	type = country_event
 	hidden = yes
@@ -20,17 +22,6 @@ no_assimilation.1 = {
 	}
 
 	immediate = {
-		if = {
-			limit = {
-				has_law_or_variant = law_type:law_multicultural
-			}
-			add_modifier = modifier_no_assimilation
-		}
-		else_if = {
-			limit = {
-				has_modifier = modifier_no_assimilation
-			}
-			remove_modifier = modifier_no_assimilation
-		}
+		mym_sync_no_assimilation_modifier = yes
 	}
 }

--- a/events/mym_no_assimilation_events.txt
+++ b/events/mym_no_assimilation_events.txt
@@ -1,0 +1,36 @@
+namespace = no_assimilation
+
+# Keeps modifier_no_assimilation in sync with the citizenship law:
+# Multicultural countries do not assimilate their pops at all.
+no_assimilation.1 = {
+	type = country_event
+	hidden = yes
+
+	trigger = {
+		OR = {
+			AND = {
+				has_law_or_variant = law_type:law_multicultural
+				NOT = { has_modifier = modifier_no_assimilation }
+			}
+			AND = {
+				NOT = { has_law_or_variant = law_type:law_multicultural }
+				has_modifier = modifier_no_assimilation
+			}
+		}
+	}
+
+	immediate = {
+		if = {
+			limit = {
+				has_law_or_variant = law_type:law_multicultural
+			}
+			add_modifier = modifier_no_assimilation
+		}
+		else_if = {
+			limit = {
+				has_modifier = modifier_no_assimilation
+			}
+			remove_modifier = modifier_no_assimilation
+		}
+	}
+}

--- a/localization/english/mym_modifiers_l_english.yml
+++ b/localization/english/mym_modifiers_l_english.yml
@@ -16,3 +16,4 @@
   modifier_has_unhealthy_economy: "Has Unhealthy Economy"
   modifier_force_privatization: "Forced Privatization"
   modifier_miskatonic_acquisition: "Miskatonic Acquisition"
+  modifier_no_assimilation: "No Assimilation"


### PR DESCRIPTION
## Summary

Countries with `law_multicultural` (or a variant of it) no longer assimilate their pops at all. A new static modifier `modifier_no_assimilation` grants `state_assimilation_mult = -0.75` nationwide, which stacks with the law's own `-0.25` to exactly **-100% assimilation**.

## Changes

- **`common/static_modifiers/mym_static_modifiers.txt`**: new `modifier_no_assimilation` (-75% assimilation, applied country-wide).
- **`common/scripted_effects/mym_scripted_effects.txt`**: new idempotent `mym_sync_no_assimilation_modifier` effect — adds the modifier only when missing and removes it only when wrongly present, based on `has_law_or_variant = law_type:law_multicultural`.
- **`common/on_actions/mym_on_actions.txt`**:
  - `on_law_activated` syncs the modifier the moment any law comes into force (enacted, imposed or script-activated).
  - `on_game_started_after_lobby` syncs every country so multicultural starts get the modifier immediately.
  - `on_country_formed` syncs newly formed/released countries.
  - Hidden event registered in the existing `on_monthly_pulse_country_mym_events` list.
- **`events/mym_no_assimilation_events.txt`**: hidden country event `no_assimilation.1` as monthly safety net; its trigger only fires when the modifier has drifted out of sync.
- **`localization/english/mym_modifiers_l_english.yml`**: localization for the new modifier.

## Testing

- Brace balance verified on all touched script files.
- Localization file keeps its UTF-8 BOM.

https://claude.ai/code/session_011Q4mG8zLyaX7mRwM3kaec6

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q4mG8zLyaX7mRwM3kaec6)_