### PR TITLE
Add vice-monarchy and vice-regency government types for puppet monarchies

### DIFF
--- a/common/government_types/00_mym_regency.txt
+++ b/common/government_types/00_mym_regency.txt
@@ -1,4 +1,47 @@
-﻿### Military Regency
+﻿### Vice-Regency
+# Regency counterpart to the vice-monarchy family (see
+# 00_mym_vice_monarchies.txt): a puppet monarchy whose throne stands vacant.
+# The Vice-Regent governs on behalf of the absent monarch and, above them,
+# of the overlord. Listed first in this file so that for puppets it takes
+# priority over the Military and Noble Regency below — the puppet status
+# defines the regime no matter which interest group the Regent comes from.
+gov_mym_vice_regency = {
+	transfer_of_power = hereditary
+
+	male_ruler = "RULER_TITLE_MYM_VICE_REGENT"
+	female_ruler = "RULER_TITLE_MYM_VICE_REGENT"
+
+	male_heir = "RULER_TITLE_HEIR_APPARENT"
+	female_heir = "RULER_TITLE_HEIR_APPARENT"
+
+	possible = {
+		country_has_monarchy_law = yes
+		is_subject_type = subject_type_puppet
+		OR = { # Same tier coverage as the vice-monarchy family
+			country_tier = kingdom
+			country_tier = principality
+			AND = {
+				country_tier = grand_principality
+				is_not_in_geographic_region = geographic_region_europe
+			}
+		}
+		# Keep the culturally specific vanilla regency flavour types
+		has_indian_primary_culture = no
+		NOT = { country_has_primary_culture = cu:swahili }
+		NOT = { c:TRI ?= this }
+		NOT = { c:HAI ?= this }
+		has_gov_regency = yes
+	}
+
+	on_government_type_change = {
+		change_to_hereditary = yes
+	}
+	on_post_government_type_change = {
+		post_change_to_hereditary = yes
+	}
+}
+
+### Military Regency
 # Triggered when the country has an active regency (gov_regency) and the
 # selected Regent is the leader of the Armed Forces interest group.
 # The regency modifier modifier_regency_armed_forces is added by vanilla

--- a/common/government_types/00_mym_vice_monarchies.txt
+++ b/common/government_types/00_mym_vice_monarchies.txt
@@ -1,0 +1,104 @@
+### Vice-Monarchies
+# Government types for monarchies that are ruled as a puppet of another
+# power: the crown is held in trust for the overlord, and the local ruler
+# reigns under a vice-regal title. Each type only applies to monarchies of
+# its respective country tier, mirroring the generic vanilla types:
+#   - Viceroyalty        -> kingdom tier              (mirrors gov_kingdom)
+#   - Vice-Duchy         -> principality tier, Europe (mirrors gov_duchy)
+#   - Vice-Principality  -> principality tier, rest   (mirrors gov_principality)
+# File is named 00_* so it is evaluated before 01_monarchies.txt and takes
+# priority over the generic tier-based monarchy types. Culturally specific
+# vanilla flavour for puppet monarchies (Indian princely states, the Swahili
+# wilayah, the Ottoman vilayet of Tripoli, Haiti) is excluded explicitly so
+# those types keep applying.
+
+gov_mym_viceroyalty = {
+	transfer_of_power = hereditary
+
+	male_ruler = "RULER_TITLE_MYM_VICEROY"
+	female_ruler = "RULER_TITLE_MYM_VICEREINE"
+
+	male_heir = "RULER_TITLE_PRINCE"
+	female_heir = "RULER_TITLE_PRINCESS"
+
+	possible = {
+		has_law = law_type:law_monarchy
+		country_tier = kingdom
+		is_subject_type = subject_type_puppet
+		has_indian_primary_culture = no # princely states keep their flavour types
+		has_gov_regency = no
+		is_domain_alliance_gov = no
+	}
+
+	on_government_type_change = {
+		change_to_hereditary = yes
+	}
+	on_post_government_type_change = {
+		post_change_to_hereditary = yes
+	}
+}
+
+gov_mym_vice_duchy = {
+	transfer_of_power = hereditary
+
+	male_ruler = "RULER_TITLE_MYM_VICE_DUKE"
+	female_ruler = "RULER_TITLE_MYM_VICE_DUCHESS"
+
+	male_heir = "" # Empty on purpose, mirrors gov_duchy
+	female_heir = "" # Empty on purpose, mirrors gov_duchy
+
+	possible = {
+		has_law = law_type:law_monarchy
+		country_tier = principality
+		is_in_geographic_region = geographic_region_europe
+		is_subject_type = subject_type_puppet
+		hidden_trigger = { # Monaco is a Principality despite being in Europe, mirrors gov_duchy
+			NOT = {
+				c:MON ?= ROOT
+			}
+		}
+		has_gov_regency = no
+		is_domain_alliance_gov = no
+	}
+
+	on_government_type_change = {
+		change_to_hereditary = yes
+	}
+	on_post_government_type_change = {
+		post_change_to_hereditary = yes
+	}
+}
+
+gov_mym_vice_principality = {
+	transfer_of_power = hereditary
+
+	male_ruler = "RULER_TITLE_MYM_VICE_PRINCE"
+	female_ruler = "RULER_TITLE_MYM_VICE_PRINCESS"
+
+	male_heir = "" # Empty on purpose, mirrors gov_principality
+	female_heir = "" # Empty on purpose, mirrors gov_principality
+
+	possible = {
+		has_law = law_type:law_monarchy
+		country_tier = principality
+		OR = { # Monaco is a Principality despite being in Europe, mirrors gov_absolute_principality
+			is_not_in_geographic_region = geographic_region_europe
+			c:MON ?= ROOT
+		}
+		is_subject_type = subject_type_puppet
+		# Keep the culturally specific vanilla flavour types for puppets
+		has_indian_primary_culture = no
+		NOT = { country_has_primary_culture = cu:swahili }
+		NOT = { c:TRI ?= this }
+		NOT = { c:HAI ?= this }
+		has_gov_regency = no
+		is_domain_alliance_gov = no
+	}
+
+	on_government_type_change = {
+		change_to_hereditary = yes
+	}
+	on_post_government_type_change = {
+		post_change_to_hereditary = yes
+	}
+}

--- a/common/government_types/00_mym_vice_monarchies.txt
+++ b/common/government_types/00_mym_vice_monarchies.txt
@@ -52,7 +52,7 @@ gov_mym_vice_duchy = {
 		country_tier = principality
 		is_in_geographic_region = geographic_region_europe
 		is_subject_type = subject_type_puppet
-		hidden_trigger = { # Monaco is a Principality despite being in Europe, mirrors gov_duchy
+		hidden_trigger = { # Montenegro is a Principality despite being in Europe, mirrors gov_duchy
 			NOT = {
 				c:MON ?= ROOT
 			}
@@ -81,7 +81,7 @@ gov_mym_vice_principality = {
 	possible = {
 		has_law = law_type:law_monarchy
 		country_tier = principality
-		OR = { # Monaco is a Principality despite being in Europe, mirrors gov_absolute_principality
+		OR = { # Montenegro is a Principality despite being in Europe, mirrors gov_absolute_principality
 			is_not_in_geographic_region = geographic_region_europe
 			c:MON ?= ROOT
 		}

--- a/common/government_types/00_mym_vice_monarchies.txt
+++ b/common/government_types/00_mym_vice_monarchies.txt
@@ -5,7 +5,8 @@
 # its respective country tier, mirroring the generic vanilla types:
 #   - Viceroyalty        -> kingdom tier              (mirrors gov_kingdom)
 #   - Vice-Duchy         -> principality tier, Europe (mirrors gov_duchy)
-#   - Vice-Principality  -> principality tier, rest   (mirrors gov_principality)
+#   - Vice-Principality  -> principality and grand_principality tier, rest
+#                           (mirrors gov_principality / gov_grand_principality)
 # File is named 00_* so it is evaluated before 01_monarchies.txt and takes
 # priority over the generic tier-based monarchy types. Culturally specific
 # vanilla flavour for puppet monarchies (Indian princely states, the Swahili
@@ -80,7 +81,10 @@ gov_mym_vice_principality = {
 
 	possible = {
 		has_law = law_type:law_monarchy
-		country_tier = principality
+		OR = {
+			country_tier = principality
+			country_tier = grand_principality
+		}
 		OR = { # Montenegro is a Principality despite being in Europe, mirrors gov_absolute_principality
 			is_not_in_geographic_region = geographic_region_europe
 			c:MON ?= ROOT

--- a/common/government_types/00_mym_vice_monarchies.txt
+++ b/common/government_types/00_mym_vice_monarchies.txt
@@ -7,6 +7,8 @@
 #   - Vice-Duchy         -> principality tier, Europe (mirrors gov_duchy)
 #   - Vice-Principality  -> principality and grand_principality tier, rest
 #                           (mirrors gov_principality / gov_grand_principality)
+# The regency counterpart (Vice-Regency, gov_mym_vice_regency) lives in
+# 00_mym_regency.txt together with the other regency types.
 # File is named 00_* so it is evaluated before 01_monarchies.txt and takes
 # priority over the generic tier-based monarchy types. Culturally specific
 # vanilla flavour for puppet monarchies (Indian princely states, the Swahili

--- a/localization/english/mym_government_l_english.yml
+++ b/localization/english/mym_government_l_english.yml
@@ -18,9 +18,25 @@
   gov_swiss_federation_dictator: "Plenipotentiary Regime"
   gov_swiss_federation_dictator_desc: "The Federal Council governs by emergency decree under #italic Vollmachten#! granted outside the ordinary constitutional process. Parliament and people are bypassed; the [Concept('concept_ruler','$RULER_TITLE_PLENIPOTENTIARY$')] rules the Confederation by fiat.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
 
+# Vice-Monarchies
+  gov_mym_viceroyalty: "Viceroyalty"
+  gov_mym_viceroyalty_desc: "A [concept_government_type] where a kingdom is governed as a [concept_puppet] of a foreign power. Its [Concept('concept_ruler','$RULER_TITLE_MYM_VICEROY$')] or [Concept('concept_ruler','$RULER_TITLE_MYM_VICEREINE$')] wears the trappings of royalty, but reigns in the name — and at the pleasure — of the [concept_overlord].\n\n$TRANSFER_OF_POWER_NAME_DESC$"
+
+  gov_mym_vice_duchy: "Vice-Duchy"
+  gov_mym_vice_duchy_desc: "A [concept_government_type] where a duchy is governed as a [concept_puppet] of a foreign power. Its [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_DUKE$')] or [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_DUCHESS$')] holds court at home, but the ducal seal is set to no document the [concept_overlord] would not countersign.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
+
+  gov_mym_vice_principality: "Vice-Principality"
+  gov_mym_vice_principality_desc: "A [concept_government_type] where a principality is governed as a [concept_puppet] of a foreign power. Its [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_PRINCE$')] or [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_PRINCESS$')] rules by hereditary right, yet every act of state defers to the will of the [concept_overlord].\n\n$TRANSFER_OF_POWER_NAME_DESC$"
+
 ### RULER TITLE ###
   RULER_TITLE_MYM_LORD_COMMANDER: "Lord Commander"
   RULER_TITLE_MYM_LORD_REGENT: "Lord Regent"
   RULER_TITLE_LANDAMMANN: "Landammann"
   RULER_TITLE_FEDERAL_PRESIDENT: "Federal President"
   RULER_TITLE_PLENIPOTENTIARY: "Plenipotentiary Chair"
+  RULER_TITLE_MYM_VICEROY: "Viceroy"
+  RULER_TITLE_MYM_VICEREINE: "Vicereine"
+  RULER_TITLE_MYM_VICE_DUKE: "Vice-Duke"
+  RULER_TITLE_MYM_VICE_DUCHESS: "Vice-Duchess"
+  RULER_TITLE_MYM_VICE_PRINCE: "Vice-Prince"
+  RULER_TITLE_MYM_VICE_PRINCESS: "Vice-Princess"

--- a/localization/english/mym_government_l_english.yml
+++ b/localization/english/mym_government_l_english.yml
@@ -28,6 +28,9 @@
   gov_mym_vice_principality: "Vice-Principality"
   gov_mym_vice_principality_desc: "A [concept_government_type] where a principality is governed as a [concept_puppet] of a foreign power. Its [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_PRINCE$')] or [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_PRINCESS$')] rules by hereditary right, yet every act of state defers to the will of the [concept_overlord].\n\n$TRANSFER_OF_POWER_NAME_DESC$"
 
+  gov_mym_vice_regency: "Vice-Regency"
+  gov_mym_vice_regency_desc: "A [concept_government_type] where the throne of a [concept_puppet] monarchy stands vacant. A [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_REGENT$')] carries on the government in the name of a monarch unable to take the throne — and, above them, in the name of the [concept_overlord], at whose pleasure the regency is suffered to continue.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
+
 ### RULER TITLE ###
   RULER_TITLE_MYM_LORD_COMMANDER: "Lord Commander"
   RULER_TITLE_MYM_LORD_REGENT: "Lord Regent"
@@ -40,3 +43,4 @@
   RULER_TITLE_MYM_VICE_DUCHESS: "Vice-Duchess"
   RULER_TITLE_MYM_VICE_PRINCE: "Vice-Prince"
   RULER_TITLE_MYM_VICE_PRINCESS: "Vice-Princess"
+  RULER_TITLE_MYM_VICE_REGENT: "Vice-Regent"


### PR DESCRIPTION
## Summary
This PR introduces four new government types for monarchies that are ruled as puppets of foreign powers, providing vice-regal titles and flavour across the relevant country tiers — including a regency variant for when the throne stands vacant.

## Key Changes
- **New Government Types**: Added four vice-monarchy government types that mirror the corresponding vanilla monarchy/regency types:
  - `gov_mym_viceroyalty` — kingdom-tier puppet monarchies
  - `gov_mym_vice_duchy` — European principality-tier puppet monarchies
  - `gov_mym_vice_principality` — non-European principality- **and grand-principality-tier** puppet monarchies
  - `gov_mym_vice_regency` — puppet monarchies under an active regency (throne vacant), covering the same tiers as the family above

- **Ruler Titles**: Introduced seven new ruler titles with appropriate gendered variants:
  - Viceroy / Vicereine
  - Vice-Duke / Vice-Duchess
  - Vice-Prince / Vice-Princess
  - Vice-Regent

- **Localization**: Added English localization for all new government types and ruler titles, with descriptive flavour text emphasizing the puppet relationship with the overlord.

## Implementation Details
- The three non-regency types live in `00_mym_vice_monarchies.txt` (named `00_*` to ensure evaluation priority over the vanilla tier-based monarchy types). They all require `has_law = law_type:law_monarchy` and `is_subject_type = subject_type_puppet`.
- `gov_mym_vice_principality` covers both `principality` and `grand_principality` tiers outside Europe, mirroring `gov_principality` / `gov_grand_principality`.
- The regency variant `gov_mym_vice_regency` lives in `00_mym_regency.txt` alongside the other regency types (it keys off `has_gov_regency = yes`). It is listed first so that for puppets it takes priority over the MyM Military/Noble Regency types — puppet status defines the regime regardless of which interest group the Regent comes from.
- Explicit exclusions preserve the culturally specific vanilla flavour types for Indian princely states, the Swahili wilayah, the Ottoman vilayet of Tripoli, and Haiti.
- Montenegro (MON) is handled as a special case in the duchy/principality types to match vanilla behaviour.
- All types use hereditary transfer of power with appropriate succession mechanics.

https://claude.ai/code/session_01WoH8doiwD1nqq1Uwac6FLo