### PR TITLE
Use priority 0 + explicit ordering for MyM dynamic country names

### DIFF
--- a/common/dynamic_country_names/mym_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mym_dynamic_country_names.txt
@@ -1,88 +1,98 @@
 ﻿# MyM dynamic country names.
 #
-# The generic government-type names below use NEGATIVE priorities so that ANY vanilla
-# dynamic country name (vanilla uses priority >= 0) always wins. This keeps vanilla flavour
-# names intact - e.g. a communist Russia stays "Soviet Union" / "Russian Soviet Republic"
-# instead of becoming the generic communist name, and tagged republics keep "Russian Republic"
-# etc. Relative order among the MyM names is preserved:
-#   -1  theocracy_* / anarchic   (was 3)
-#   -2  junta / high_command / islamic_republic   (was 2)
-#   -3  communist_* / fascist_state / republic / technocracy   (was 1)
-# Tie-break (see dynamic_country_names.md): equal priority -> first defined in load order wins,
-# and 00_dynamic_country_names.txt loads before this file, so vanilla also wins any tie at 0.
+# All generic government-type names below use priority 0. A dynamic name whose trigger passes
+# always overrides the plain (base) country name, so these still apply - but every vanilla
+# dynamic country name takes precedence over them: vanilla names with priority > 0 win outright,
+# and vanilla names with priority 0 win the tie because 00_dynamic_country_names.txt loads before
+# this file ("if same priority, first one in file is used", see dynamic_country_names.md).
+# Net order:  specific vanilla name  >  these MyM names  >  plain country name.
 #
-# Kept above vanilla on purpose: dyn_c_zhuz (UZH/KZH/OZH have no vanilla dynamic names) and
-# dyn_c_bananada (deliberate flavour override for a banana-republic Canada).
+# Because everything here shares priority 0, the FIRST matching entry wins, so the entries are
+# ordered from most to least specific to reproduce the original precedence:
+#   theocracy_* / anarchic                              (were priority 3)
+#   junta / high_command / zhuz / islamic_republic      (were priority 2)
+#   communist_* / fascist_state / republic / technocracy (were priority 1)
+#
+# dyn_c_bananada keeps priority 200 on purpose: a deliberate flavour override for a
+# banana-republic Canada (the one place MyM intentionally beats the vanilla name).
 INJECT:DEFAULT = {
 	dynamic_country_name = {
-		name = dyn_c_communist_democracy
+		name = dyn_c_anarchic
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -3
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
 				has_law_or_variant = law_type:law_council_republic
-				country_has_voting_franchise = yes
-				NOT = { has_law_or_variant = law_type:law_single_party_state }
+				has_law_or_variant = law_type:law_anarchy
 			}
 		}
 	}
 	dynamic_country_name = {
-		name = dyn_c_communist_autocracy
+		name = dyn_c_theocracy_christian
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -3
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
-				has_law_or_variant = law_type:law_council_republic
-				OR = {
-					country_has_voting_franchise = no
-					has_law_or_variant = law_type:law_single_party_state
-				}
+				is_christian = yes
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
 			}
 		}
 	}
 	dynamic_country_name = {
-		name = dyn_c_fascist_state
+		name = dyn_c_theocracy_jewish
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -3
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
-				OR = {
-					has_law_or_variant = law_type:law_presidential_republic
-					has_law_or_variant = law_type:law_parliamentary_republic
-					has_law_or_variant = law_type:law_corporate_state
-				}
-				OR = {
-					has_law_or_variant = law_type:law_autocracy
-					has_law_or_variant = law_type:law_oligarchy
-					has_law_or_variant = law_type:law_single_party_state
-				}
-				coa_fascist_trigger = yes
+				is_jewish = yes
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
 			}
 		}
 	}
 	dynamic_country_name = {
-		name = dyn_c_republic
+		name = dyn_c_theocracy_islamic
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -3
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
-				NOR = {
-					c:USA ?= this
-					c:CSA ?= this
-					has_law_or_variant = law_type:law_monarchy
+				religion = {
+					has_discrimination_trait = heritage_islamic
 				}
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_theocracy_voting
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				NOT = {
+					c:PAP ?= this
+				}
+				religion = {
+					NOT = { has_discrimination_trait = heritage_islamic }
+				}
+				has_law_or_variant = law_type:law_theocracy
 				country_has_voting_franchise = yes
 			}
 		}
@@ -92,7 +102,7 @@ INJECT:DEFAULT = {
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -2
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
@@ -118,7 +128,7 @@ INJECT:DEFAULT = {
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -2
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
@@ -152,7 +162,7 @@ INJECT:DEFAULT = {
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = 2
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
@@ -171,7 +181,7 @@ INJECT:DEFAULT = {
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -2
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
@@ -190,97 +200,89 @@ INJECT:DEFAULT = {
 		}
 	}
 	dynamic_country_name = {
+		name = dyn_c_communist_democracy
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				has_law_or_variant = law_type:law_council_republic
+				country_has_voting_franchise = yes
+				NOT = { has_law_or_variant = law_type:law_single_party_state }
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_communist_autocracy
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				has_law_or_variant = law_type:law_council_republic
+				OR = {
+					country_has_voting_franchise = no
+					has_law_or_variant = law_type:law_single_party_state
+				}
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_fascist_state
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				OR = {
+					has_law_or_variant = law_type:law_presidential_republic
+					has_law_or_variant = law_type:law_parliamentary_republic
+					has_law_or_variant = law_type:law_corporate_state
+				}
+				OR = {
+					has_law_or_variant = law_type:law_autocracy
+					has_law_or_variant = law_type:law_oligarchy
+					has_law_or_variant = law_type:law_single_party_state
+				}
+				coa_fascist_trigger = yes
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_republic
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				NOR = {
+					c:USA ?= this
+					c:CSA ?= this
+					has_law_or_variant = law_type:law_monarchy
+				}
+				country_has_voting_franchise = yes
+			}
+		}
+	}
+	dynamic_country_name = {
 		name = dyn_c_technocracy
 		adjective = root_adj
 
 		is_main_tag_only = yes
-		priority = -3
+		priority = 0
 
 		trigger = {
 			scope:actor ?= {
 				NOT = { has_law_or_variant = law_type:law_monarchy }
 				has_law_or_variant = law_type:law_technocracy
-			}
-		}
-	}
-	dynamic_country_name = {
-		name = dyn_c_anarchic
-		adjective = root_adj
-
-		is_main_tag_only = yes
-		priority = -1
-
-		trigger = {
-			scope:actor ?= {
-				has_law_or_variant = law_type:law_council_republic
-				has_law_or_variant = law_type:law_anarchy
-			}
-		}
-	}
-	dynamic_country_name = {
-		name = dyn_c_theocracy_christian
-		adjective = root_adj
-
-		is_main_tag_only = yes
-		priority = -1
-
-		trigger = {
-			scope:actor ?= {
-				is_christian = yes
-				has_law_or_variant = law_type:law_theocracy
-				country_has_voting_franchise = no
-			}
-		}
-	}
-	dynamic_country_name = {
-		name = dyn_c_theocracy_jewish
-		adjective = root_adj
-
-		is_main_tag_only = yes
-		priority = -1
-
-		trigger = {
-			scope:actor ?= {
-				is_jewish = yes
-				has_law_or_variant = law_type:law_theocracy
-				country_has_voting_franchise = no
-			}
-		}
-	}
-	dynamic_country_name = {
-		name = dyn_c_theocracy_islamic
-		adjective = root_adj
-
-		is_main_tag_only = yes
-		priority = -1
-
-		trigger = {
-			scope:actor ?= {
-				religion = {
-					has_discrimination_trait = heritage_islamic
-				}
-				has_law_or_variant = law_type:law_theocracy
-				country_has_voting_franchise = no
-			}
-		}
-	}
-	dynamic_country_name = {
-		name = dyn_c_theocracy_voting
-		adjective = root_adj
-
-		is_main_tag_only = yes
-		priority = -1
-
-		trigger = {
-			scope:actor ?= {
-				NOT = {
-					c:PAP ?= this
-				}
-				religion = {
-					NOT = { has_discrimination_trait = heritage_islamic }
-				}
-				has_law_or_variant = law_type:law_theocracy
-				country_has_voting_franchise = yes
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Follow-up to #47. That PR used **negative** priorities to make the MyM dynamic country names defer to vanilla; this replaces that with a scheme that relies only on **documented** engine behaviour, so it no longer depends on how the engine treats negative priority values.

The goal is a clean three-tier order: **specific vanilla name > MyM name > plain (base) country name.**

## What changed
- All generic government-type names now use **priority 0** instead of negative values.
  - A dynamic name whose trigger passes always overrides the plain base country name, so the MyM names still apply (the same way vanilla's own priority-0 names override the base name).
  - Every vanilla dynamic name still takes precedence: priority &gt; 0 wins outright, and priority 0 wins the tie because `00_dynamic_country_names.txt` loads before this file (*"if same priority, first one in file is used"*, per `dynamic_country_names.md`).
- Because all entries share priority 0, they are **reordered** so the first match wins, reproducing the original precedence exactly:
  `theocracy_* / anarchic` &gt; `junta / high_command / zhuz / islamic_republic` &gt; `communist_* / fascist_state / republic / technocracy`.
- **Triggers are unchanged** (verified line-by-line against the previous version). `dyn_c_bananada` keeps priority 200 as a deliberate banana-republic Canada flavour override.

## Why
The negative-priority approach in #47 hinged on the engine treating negative priority as "valid but lowest". This version guarantees "MyM beats the base name" the same proven way vanilla does, removing that assumption. The only remaining dependency is the documented load-order tie-break that lets vanilla's priority-0 names win.

https://claude.ai/code/session_01TTvFyoRWQYqyVCYoGhorRy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTvFyoRWQYqyVCYoGhorRy)_