### PR TITLE
Treat social monarchies as monarchies in dynamic country names

### DIFF
--- a/common/dynamic_country_names/mym_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mym_dynamic_country_names.txt
@@ -187,6 +187,7 @@ INJECT:DEFAULT = {
 			scope:actor ?= {
 				NOR = {
 					has_law_or_variant = law_type:law_monarchy
+					has_law_or_variant = law_type:law_social_monarchy
 					is_country_type = decentralized
 				}
 				OR = {
@@ -267,6 +268,7 @@ INJECT:DEFAULT = {
 					c:USA ?= this
 					c:CSA ?= this
 					has_law_or_variant = law_type:law_monarchy
+					has_law_or_variant = law_type:law_social_monarchy
 				}
 				country_has_voting_franchise = yes
 			}
@@ -281,7 +283,10 @@ INJECT:DEFAULT = {
 
 		trigger = {
 			scope:actor ?= {
-				NOT = { has_law_or_variant = law_type:law_monarchy }
+				NOR = {
+					has_law_or_variant = law_type:law_monarchy
+					has_law_or_variant = law_type:law_social_monarchy
+				}
 				has_law_or_variant = law_type:law_technocracy
 			}
 		}


### PR DESCRIPTION
## What the player notices

Social monarchies now keep a proper monarchy name on the map instead of being mislabelled with a republic-style name.

## Why

`law_social_monarchy` is a separate governance principle from `law_monarchy`. The generic dynamic country names in `common/dynamic_country_names/mym_dynamic_country_names.txt` only excluded `law_monarchy`, so a social monarchy slipped through and picked up the wrong generic name:

- **with voting franchise** → matched `dyn_c_republic` → *"… Republic"*
- **islamic heritage + state religion / freedom of conscience** → matched `dyn_c_islamic_republic` → *"… Islamic Republic"*
- **technocracy distribution of power** → matched `dyn_c_technocracy` → *"… Directorate"* (`law_technocracy` lives in the orthogonal `lawgroup_distribution_of_power`, so it can combine with a social monarchy)

## Change

Per request: no dedicated social-monarchy name is introduced. Instead `law_social_monarchy` is added next to `law_monarchy` in the monarchy-exclusion triggers of `dyn_c_republic`, `dyn_c_islamic_republic` and `dyn_c_technocracy`, so a social monarchy is treated like any other monarchy and falls through to its specific vanilla / plain monarchy name.

The other generic entries don't need touching: they gate on mutually exclusive governance principles (`law_council_republic`, `law_presidential_republic`, `law_theocracy`, …) that a social monarchy can never hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQUNLpecyb1rHgs85cbk7k)_