### PR TITLE
australian_flavour.1: prefer player subjects, gate on 75% turmoil, reframe as convict transportation

### DIFF
--- a/common/script_values/mym_australian_flavour_values.txt
+++ b/common/script_values/mym_australian_flavour_values.txt
@@ -1,6 +1,6 @@
-﻿# Script values backing the GBR radical-deportation event (australian_flavour.1).
+﻿# Script values backing the GBR convict-transportation event (australian_flavour.1).
 # The three state-level values iterate the pops of the state they are evaluated
-# in. ROOT is the deporting country (Great Britain).
+# in. ROOT is the transporting country (Great Britain).
 
 # Radicals living in a single pop: its size weighted by its radical fraction.
 # Evaluated in pop scope. Used both to rank the language-sharing pops (so the

--- a/common/scripted_triggers/mym_australian_flavour_triggers.txt
+++ b/common/scripted_triggers/mym_australian_flavour_triggers.txt
@@ -1,12 +1,12 @@
-﻿# Trigger backing the GBR radical-deportation event (australian_flavour.1).
+﻿# Trigger backing the GBR convict-transportation event (australian_flavour.1).
 # Kept in its own file alongside mym_australian_flavour_values.txt so the
 # whole feature stays in one place.
 
 # True for an incorporated state of ROOT (intended: GBR) that is ripe for the
-# deportation: high state turmoil (at least 75%) on top of a radical majority,
+# transportation: high state turmoil (at least 75%) on top of a radical majority,
 # of whom at least a quarter belong to cultures sharing the language of one of
 # ROOT's primary cultures.
-mym_state_ripe_for_radical_deportation = {
+mym_state_ripe_for_convict_transportation = {
 	is_incorporated = yes
 	turmoil >= 0.75
 	radical_fraction = { value > 0.5 }

--- a/common/scripted_triggers/mym_australian_flavour_triggers.txt
+++ b/common/scripted_triggers/mym_australian_flavour_triggers.txt
@@ -3,10 +3,11 @@
 # whole feature stays in one place.
 
 # True for an incorporated state of ROOT (intended: GBR) that is ripe for the
-# deportation: a radical majority, of whom at least a quarter belong to
-# cultures sharing the language of one of ROOT's primary cultures.
+# deportation: a radical supermajority (over three-quarters of the state), of
+# whom at least a quarter belong to cultures sharing the language of one of
+# ROOT's primary cultures.
 mym_state_ripe_for_radical_deportation = {
 	is_incorporated = yes
-	radical_fraction = { value > 0.5 }
+	radical_fraction = { value > 0.75 }
 	mym_state_radicals_sharing_primary_language >= mym_state_radicals_total_quarter
 }

--- a/common/scripted_triggers/mym_australian_flavour_triggers.txt
+++ b/common/scripted_triggers/mym_australian_flavour_triggers.txt
@@ -3,11 +3,12 @@
 # whole feature stays in one place.
 
 # True for an incorporated state of ROOT (intended: GBR) that is ripe for the
-# deportation: a radical supermajority (over three-quarters of the state), of
-# whom at least a quarter belong to cultures sharing the language of one of
+# deportation: high state turmoil (at least 75%) on top of a radical majority,
+# of whom at least a quarter belong to cultures sharing the language of one of
 # ROOT's primary cultures.
 mym_state_ripe_for_radical_deportation = {
 	is_incorporated = yes
-	radical_fraction = { value > 0.75 }
+	turmoil >= 0.75
+	radical_fraction = { value > 0.5 }
 	mym_state_radicals_sharing_primary_language >= mym_state_radicals_total_quarter
 }

--- a/events/mym_australian_flavour_events.txt
+++ b/events/mym_australian_flavour_events.txt
@@ -68,11 +68,33 @@ australian_flavour.1 = {
 		}
 
 		# Destination: a random state of a random Australian-cultured subject.
-		random_subject_or_below = {
-			limit = { country_has_primary_culture = cu:australian }
-			save_scope_as = destination_country
-			random_scope_state = {
-				save_scope_as = destination_state
+		# Prefer a player-controlled Australian subject; only when none of the
+		# Australian-cultured subjects is a player do we fall back to a random one.
+		if = {
+			limit = {
+				any_subject_or_below = {
+					country_has_primary_culture = cu:australian
+					is_player = yes
+				}
+			}
+			random_subject_or_below = {
+				limit = {
+					country_has_primary_culture = cu:australian
+					is_player = yes
+				}
+				save_scope_as = destination_country
+				random_scope_state = {
+					save_scope_as = destination_state
+				}
+			}
+		}
+		else = {
+			random_subject_or_below = {
+				limit = { country_has_primary_culture = cu:australian }
+				save_scope_as = destination_country
+				random_scope_state = {
+					save_scope_as = destination_state
+				}
 			}
 		}
 	}

--- a/events/mym_australian_flavour_events.txt
+++ b/events/mym_australian_flavour_events.txt
@@ -4,7 +4,7 @@
 # 5-year cooldown. When one of Britain's incorporated home states is overrun by
 # radicals who speak a British primary language, the Crown may transport half of
 # the worst-affected pop to one of its Australian-cultured subjects, assimilating
-# the deportees to Australian on the way out.
+# the convicts to Australian on the way out.
 australian_flavour.1 = {
 	type = country_event
 	placement = scope:radical_state
@@ -30,7 +30,7 @@ australian_flavour.1 = {
 		c:GBR ?= root
 
 		# At least one subject (or sub-subject) is Australian by primary culture
-		# to receive the deportees.
+		# to receive the convicts.
 		any_subject_or_below = {
 			country_has_primary_culture = cu:australian
 		}
@@ -38,16 +38,16 @@ australian_flavour.1 = {
 		# At least one incorporated state is radical-majority with a strong
 		# British-speaking radical contingent.
 		any_scope_state = {
-			mym_state_ripe_for_radical_deportation = yes
+			mym_state_ripe_for_convict_transportation = yes
 		}
 	}
 
 	immediate = {
 		# ROOT is GBR here; remembered for the receiving subject's notification.
-		save_scope_as = deporting_country
+		save_scope_as = transporting_country
 
 		random_scope_state = {
-			limit = { mym_state_ripe_for_radical_deportation = yes }
+			limit = { mym_state_ripe_for_convict_transportation = yes }
 			save_scope_as = radical_state
 
 			# The single pop holding the most radicals among those that share a
@@ -63,7 +63,7 @@ australian_flavour.1 = {
 				order_by = mym_pop_radical_count
 				position = 0
 				check_range_bounds = no
-				save_scope_as = deported_pop
+				save_scope_as = convict_pop
 			}
 		}
 
@@ -103,11 +103,11 @@ australian_flavour.1 = {
 		name = australian_flavour.1.a
 		default_option = yes
 		# Assimilate half of the offending pop to Australian, then ship the
-		# freshly-Australian deportees off to the chosen subject state; the
+		# freshly-Australian convicts off to the chosen subject state; the
 		# other half stays behind. change_pop_culture only takes a literal
 		# fraction, so we recolour in place and move the resulting Australian
 		# pop rather than trying to recolour pops after the move.
-		scope:deported_pop = {
+		scope:convict_pop = {
 			change_pop_culture = {
 				target = cu:australian
 				value  = 0.5
@@ -131,8 +131,8 @@ australian_flavour.1 = {
 	}
 }
 
-# Notification fired on the receiving Australian subject when the deportees
-# arrive. ROOT here is the subject; the destination state appears in the title.
+# Notification fired on the receiving Australian subject when the convict
+# transports arrive. ROOT here is the subject; the destination state appears in the title.
 australian_flavour.2 = {
 	type = country_event
 	placement = scope:destination_state

--- a/localization/english/mym_contents_l_english.yml
+++ b/localization/english/mym_contents_l_english.yml
@@ -101,6 +101,6 @@
   australian_flavour.1.b: "We do not exile our own. Let them stew at home."
 
   australian_flavour.2.tt: "New Hands for [SCOPE.sState('destination_state').GetName]"
-  australian_flavour.2.dd: "#italic [SCOPE.sState('destination_state').GetCityHubName], [TimeKeeper.GetCurrentDate.GetString] - #!\n\nThe convict transports from [SCOPE.sCountry('deporting_country').GetName] have made landfall. Where the manifests promised radicals and firebrands, the gangways disgorge tired families clutching what they could carry — convicts with little appetite left for revolution and every reason to begin again.\n\nThey are ours now, in name and in tongue. [SCOPE.sState('destination_state').GetName] gains their backs and their grievances alike."
+  australian_flavour.2.dd: "#italic [SCOPE.sState('destination_state').GetCityHubName], [TimeKeeper.GetCurrentDate.GetString] - #!\n\nThe convict transports from [SCOPE.sCountry('transporting_country').GetName] have made landfall. Where the manifests promised radicals and firebrands, the gangways disgorge tired families clutching what they could carry — convicts with little appetite left for revolution and every reason to begin again.\n\nThey are ours now, in name and in tongue. [SCOPE.sState('destination_state').GetName] gains their backs and their grievances alike."
   australian_flavour.2.ff: "#lore #italic 'They arrived as a problem solved elsewhere. Whether they remain one is now our affair.'#!"
   australian_flavour.2.a: "Put them to work."


### PR DESCRIPTION
## What this changes

Three adjustments to the GBR `australian_flavour.1` event (Britain shipping its troublesome radicals off to an Australian-cultured subject).

### 1. Prefer player-controlled destinations
The destination subject was a flat random pick across all Australian-cultured subjects. Now, if any Australian-cultured subject is player-controlled (`is_player = yes`), the destination is chosen at random among those players; only when none of the Australian nations is a player does it fall back to a random Australian-cultured subject (the previous behaviour). The `destination_state` pick within the chosen subject is unchanged.

### 2. Gate on 75% state turmoil
The event now also requires the source state to have high **state turmoil** (`turmoil >= 0.75`) on top of the existing radical majority (`radical_fraction > 0.5`, unchanged). This makes the event fire only in genuinely unstable home states.

### 3. Reframe as penal convict transportation
The internal naming and code comments are aligned with the already convict-themed localization ("Transportation Beyond the Seas", "Sentence them as convicts"):
- trigger `mym_state_ripe_for_radical_deportation` → `mym_state_ripe_for_convict_transportation`
- scope `deporting_country` → `transporting_country`, `deported_pop` → `convict_pop`
- comments switched from deportation to convict-transportation wording

## Notes
- No `check_range_bounds = no` needed — the destination selection uses `random_*`/`if`/`else`, not `ordered_*` lists.
- File encoding preserved (UTF-8 with BOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GxfrXUZn517wsHrHqhU9n