### PR TITLE
Add Natalist Advertisement decisions and modifier

### DIFF
--- a/common/decisions/mym_decisions.txt
+++ b/common/decisions/mym_decisions.txt
@@ -95,3 +95,37 @@ decision_mym_force_privatization = {
 		value = 0
 	}
 }
+
+decision_mym_natalist_advertisement = {
+
+	is_shown = {
+		is_player = yes
+		NOT = { has_modifier = modifier_advertising_natalism }
+	}
+
+	when_taken = {
+		add_modifier = {
+			name = modifier_advertising_natalism
+		}
+	}
+
+	ai_chance = {
+		value = 0
+	}
+}
+
+decision_mym_end_natalist_advertisement = {
+
+	is_shown = {
+		is_player = yes
+		has_modifier = modifier_advertising_natalism
+	}
+
+	when_taken = {
+		remove_modifier = modifier_advertising_natalism
+	}
+
+	ai_chance = {
+		value = 0
+	}
+}

--- a/common/static_modifiers/mym_static_modifiers.txt
+++ b/common/static_modifiers/mym_static_modifiers.txt
@@ -17,3 +17,9 @@ modifier_no_assimilation = {
     # law_multicultural already grants -0.25, so the nationwide total is exactly -100%.
     state_assimilation_mult = -0.75
 }
+
+modifier_advertising_natalism = {
+    icon = gfx/interface/icons/timed_modifier_icons/modifier_documents_positive.dds
+    state_birth_rate_mult = 0.02
+    state_working_adult_ratio_add = -0.02
+}

--- a/localization/english/mym_decisions_l_english.yml
+++ b/localization/english/mym_decisions_l_english.yml
@@ -10,6 +10,10 @@
   decision_mym_enact_the_act_desc: "Consolidate the Power"
   decision_mym_force_privatization: "$mym_debug.pre.tt$: Force Privatization"
   decision_mym_force_privatization_desc: ""
+  decision_mym_natalist_advertisement: "$mym_debug.pre.tt$: Advertise Natalism"
+  decision_mym_natalist_advertisement_desc: "Launch a nationwide campaign extolling the joys of a large family. More cradles to fill means fewer hands at the workbench."
+  decision_mym_end_natalist_advertisement: "$mym_debug.pre.tt$: End Natalist Advertising"
+  decision_mym_end_natalist_advertisement_desc: "Take down the posters and let the nation get back to work."
 
 # Extra-Modificational Corrections
   Turn_on_off_ADVCM_decrees: "#red Toggle ADVCM Decrees"

--- a/localization/english/mym_modifiers_l_english.yml
+++ b/localization/english/mym_modifiers_l_english.yml
@@ -17,3 +17,4 @@
   modifier_force_privatization: "Forced Privatization"
   modifier_miskatonic_acquisition: "Miskatonic Acquisition"
   modifier_no_assimilation: "No Assimilation"
+  modifier_advertising_natalism: "Advertising Natalism"


### PR DESCRIPTION
## What this does

Adds a paired set of decisions to toggle a nationwide, timeless natalism modifier.

- **Decision "Advertise Natalism"** (`decision_mym_natalist_advertisement`) applies the nationwide modifier **Advertising Natalism** (`modifier_advertising_natalism`):
  - Birth Rate **+2%** (`state_birth_rate_mult = 0.02`)
  - Workforce Ratio **-2%** (`state_working_adult_ratio_add = -0.02`)
  - No time limit — applied via `add_modifier` without `months`/`years`.
- **Decision "End Natalist Advertising"** (`decision_mym_end_natalist_advertisement`) removes the modifier again.
- The two decisions gate on `has_modifier`, so **exactly one is ever shown** at a time.

## Notes

- The state-scoped modifier types applied via a country-scope `add_modifier` take effect nationwide — the same proven pattern already used by `modifier_force_privatization` and `modifier_no_assimilation` in this mod.
- Localization added for both decisions (with the mod's `$mym_debug.pre.tt$` branding prefix) and the modifier name.
- All touched files keep their UTF-8 BOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnHE8v5iGmiwqbAnFkZgD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnHE8v5iGmiwqbAnFkZgD9)_