### PR TITLE
Make Natalist Advertisement incompatible with Legal Guardianship

### DIFF
--- a/common/decisions/mym_decisions.txt
+++ b/common/decisions/mym_decisions.txt
@@ -100,7 +100,10 @@ decision_mym_natalist_advertisement = {
 
 	is_shown = {
 		is_player = yes
-		NOT = { has_modifier = modifier_advertising_natalism }
+		NOR = {
+			has_modifier = modifier_advertising_natalism
+			has_law = law_type:law_no_womens_rights
+		}
 	}
 
 	when_taken = {

--- a/common/on_actions/mym_on_actions.txt
+++ b/common/on_actions/mym_on_actions.txt
@@ -102,15 +102,7 @@ on_law_activated_mym = {
 	effect = {
 		owner = {
 			mym_sync_no_assimilation_modifier = yes
-			# Legal Guardianship is incompatible with the natalism campaign, so
-			# enacting it strips the Advertising Natalism modifier.
-			if = {
-				limit = {
-					has_law = law_type:law_no_womens_rights
-					has_modifier = modifier_advertising_natalism
-				}
-				remove_modifier = modifier_advertising_natalism
-			}
+			mym_sync_natalism_modifier = yes
 		}
 	}
 }

--- a/common/on_actions/mym_on_actions.txt
+++ b/common/on_actions/mym_on_actions.txt
@@ -91,8 +91,8 @@ on_country_formed_mym = {
 	}
 }
 
-# Sync the no-assimilation modifier the moment any law comes into force
-# (enacted, imposed or switched to a variant), instead of waiting for the
+# Reconcile a country's modifiers with its law set the moment any law comes into
+# force (enacted, imposed or switched to a variant), instead of waiting for the
 # monthly pulse. Scope is the law; owner is the country.
 on_law_activated = {
 	on_actions = { on_law_activated_mym }
@@ -102,6 +102,15 @@ on_law_activated_mym = {
 	effect = {
 		owner = {
 			mym_sync_no_assimilation_modifier = yes
+			# Legal Guardianship is incompatible with the natalism campaign, so
+			# enacting it strips the Advertising Natalism modifier.
+			if = {
+				limit = {
+					has_law = law_type:law_no_womens_rights
+					has_modifier = modifier_advertising_natalism
+				}
+				remove_modifier = modifier_advertising_natalism
+			}
 		}
 	}
 }

--- a/common/scripted_effects/mym_scripted_effects.txt
+++ b/common/scripted_effects/mym_scripted_effects.txt
@@ -193,3 +193,17 @@ mym_sync_no_assimilation_modifier = {
 		remove_modifier = modifier_no_assimilation
 	}
 }
+
+# Strips modifier_advertising_natalism while Legal Guardianship is in force.
+# The campaign is only ever started through decision_mym_natalist_advertisement,
+# which is gated against the law, so this only ever needs to remove.
+# Idempotent and safe to call from any country scope at any time.
+mym_sync_natalism_modifier = {
+	if = {
+		limit = {
+			has_law = law_type:law_no_womens_rights
+			has_modifier = modifier_advertising_natalism
+		}
+		remove_modifier = modifier_advertising_natalism
+	}
+}


### PR DESCRIPTION
## What this does

Follow-up to #54. Makes the Natalist Advertisement campaign mutually exclusive with the **Legal Guardianship** law (`law_no_womens_rights`), from both directions:

1. **Decision gate** (`common/decisions/mym_decisions.txt`)
   The **Advertise Natalism** decision is no longer shown while the country has Legal Guardianship. Implemented by folding the law check into the existing `NOR` alongside the modifier check, matching the `decision_mym_force_privatization` style. The removal decision stays unrestricted, so an active modifier can always be cleared.

2. **On-law-change hook** (`common/on_actions/mym_on_actions.txt`)
   The existing `on_law_activated_mym` hook now also strips the **Advertising Natalism** modifier when the country's law set includes Legal Guardianship. So enacting the law mid-campaign pulls the modifier immediately instead of leaving an illegal combination until the player toggles it off.

Together: the campaign can't be started under Legal Guardianship, and an active campaign is removed the moment the law comes into force.

## Notes

- `law_no_womens_rights` is the vanilla id for the law shown in-game as "Legal Guardianship" (verified against vanilla loc).
- The hook reuses the country (`owner`) scope already established for the no-assimilation sync; the gate uses the same `has_law` check as the decision for consistency.
- Touched files keep their UTF-8 BOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnHE8v5iGmiwqbAnFkZgD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnHE8v5iGmiwqbAnFkZgD9)_