### PR TITLE
Drop Solism ideology references from Mym debug helper

### DIFF
--- a/common/scripted_effects/mym_scripted_effects.txt
+++ b/common/scripted_effects/mym_scripted_effects.txt
@@ -4,7 +4,6 @@ custom_tooltip = {
 		every_scope_character = {
 			limit = {
 				has_role_of_type = politician
-				NOT = { has_ideology = ideology:ideology_solist }
 			}
 			random_list = {
 				1 = { set_ideology = ideology:ideology_moderate }
@@ -43,9 +42,6 @@ custom_tooltip = {
 				1 = { set_ideology = ideology:ideology_sovereignist_leader }
 				1 = { set_ideology = ideology:ideology_utopian }
 				1 = { set_ideology = ideology:ideology_modernizer_leader }
-				1 = { set_ideology = ideology:ideology_neo_industrialist }
-				1 = { set_ideology = ideology:ideology_hyper_individualist }
-				1 = { set_ideology = ideology:ideology_restorationist }
 				1 = { set_ideology = ideology:ideology_secular_humanitarian }
 			}
 		}


### PR DESCRIPTION
## What

Removes the four Solism-defined ideology references from the `set_politician_ideos_randomly` debug helper in `common/scripted_effects/mym_scripted_effects.txt`:

- `NOT = { has_ideology = ideology:ideology_solist }` (the `limit` exclusion)
- `set_ideology = ideology:ideology_neo_industrialist`
- `set_ideology = ideology:ideology_hyper_individualist`
- `set_ideology = ideology:ideology_restorationist`

## Why

My Modifications declares only **DonSantanian Resources** as a dependency, yet this debug helper referenced ideologies that are defined in **Solism**. With Solism not loaded, those references resolve to nothing. Dropping them realigns the mod with its declared dependency, so Mym no longer implicitly depends on Solism being present.

## Behavior change

The debug-only `set_politician_ideos_randomly` no longer assigns Solism ideologies and no longer excludes Solist politicians from randomization (the `ideology_solist` guard is gone). Since this is a debug helper, the change is harmless.

## Verification

- No Solism references remain in the file (`ideology_solist`, `ideology_neo_industrialist`, `ideology_hyper_individualist`, `ideology_restorationist` all gone).
- UTF-8 BOM preserved.
- Brace balance intact (97/97); effect structure unchanged otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWbW8VUjtytfiynMDjmjJK)_