### PR TITLE
Consume DSR's set_all_politicians_ideology helper

### DIFF
--- a/common/scripted_effects/mym_scripted_effects.txt
+++ b/common/scripted_effects/mym_scripted_effects.txt
@@ -53,17 +53,6 @@ custom_tooltip = {
 # Macro substitution keeps the per-ideology / per-attraction options short.
 # ---------------------------------------------------------------------------
 
-# Sets every politician that does not already hold $IDEOLOGY$ to $IDEOLOGY$.
-mym_set_all_politicians_ideology = {
-	every_scope_character = {
-		limit = {
-			has_role_of_type = politician
-			NOT = { has_ideology = ideology:$IDEOLOGY$ }
-		}
-		set_ideology = ideology:$IDEOLOGY$
-	}
-}
-
 # Promotes an existing $IDEOLOGY$ agitator to ruler, or creates one and lets
 # the next political turn pick them up.
 mym_make_agitator_ruler_or_create = {

--- a/events/mym_debug_events.txt
+++ b/events/mym_debug_events.txt
@@ -167,7 +167,7 @@ mym_debug.2 = {
 			}
 		}
 
-		mym_set_all_politicians_ideology = { IDEOLOGY = ideology_fascist }
+		set_all_politicians_ideology = { IDEOLOGY = ideology_fascist }
 
 		hidden_effect = {
 			trigger_event = { id = mym_debug.2 popup = yes }
@@ -187,7 +187,7 @@ mym_debug.2 = {
 			}
 		}
 
-		mym_set_all_politicians_ideology = { IDEOLOGY = ideology_communist }
+		set_all_politicians_ideology = { IDEOLOGY = ideology_communist }
 
 		hidden_effect = {
 			trigger_event = { id = mym_debug.2 popup = yes }
@@ -207,7 +207,7 @@ mym_debug.2 = {
 			}
 		}
 
-		mym_set_all_politicians_ideology = { IDEOLOGY = ideology_anarchist }
+		set_all_politicians_ideology = { IDEOLOGY = ideology_anarchist }
 
 		hidden_effect = {
 			trigger_event = { id = mym_debug.2 popup = yes }
@@ -227,7 +227,7 @@ mym_debug.2 = {
 			}
 		}
 
-		mym_set_all_politicians_ideology = { IDEOLOGY = ideology_anarcho_libertarian }
+		set_all_politicians_ideology = { IDEOLOGY = ideology_anarcho_libertarian }
 
 		hidden_effect = {
 			trigger_event = { id = mym_debug.2 popup = yes }
@@ -247,7 +247,7 @@ mym_debug.2 = {
 			}
 		}
 
-		mym_set_all_politicians_ideology = { IDEOLOGY = ideology_libertarian_utopian }
+		set_all_politicians_ideology = { IDEOLOGY = ideology_libertarian_utopian }
 
 		hidden_effect = {
 			trigger_event = { id = mym_debug.2 popup = yes }


### PR DESCRIPTION
## What this does

Removes the local `mym_set_all_politicians_ideology` macro and calls the shared **DonSantanian Resources** effect `set_all_politicians_ideology` from the debug menu instead. The effect body is identical and vanilla-only; the ideology is still passed in per option (`IDEOLOGY = …`), so behaviour is unchanged.

## Why
The helper is generic and now lives in DSR (already a declared dependency of this mod), so it no longer needs a private copy here.

## Kept local on purpose
`set_politician_ideos_randomly` stays in this mod: its random list includes `ideology_secular_humanitarian`, a **mod-defined** ideology, so the effect is not vanilla-only and does not belong in DSR.

## Companion PR
Depends on `salva133/Vic3-DonSantanian-Resources` adding `set_all_politicians_ideology` (DSR PR in the same branch). Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4Qs7Xp2FDnQ8eN2HBzrET)_