### PR TITLE
Make Force Privatization a toggle (paired decisions, non-timed modifier)

### DIFF
--- a/common/decisions/mym_decisions.txt
+++ b/common/decisions/mym_decisions.txt
@@ -88,8 +88,20 @@ decision_mym_force_privatization = {
 	when_taken = {
 		add_modifier = {
 			name = modifier_force_privatization
-			months = 3
 		}
+	}
+	ai_chance = {
+		value = 0
+	}
+}
+
+decision_mym_end_force_privatization = {
+	is_shown = {
+		is_player = yes
+		has_modifier = modifier_force_privatization
+	}
+	when_taken = {
+		remove_modifier = modifier_force_privatization
 	}
 	ai_chance = {
 		value = 0

--- a/localization/english/mym_decisions_l_english.yml
+++ b/localization/english/mym_decisions_l_english.yml
@@ -10,6 +10,8 @@
   decision_mym_enact_the_act_desc: "Consolidate the Power"
   decision_mym_force_privatization: "$mym_debug.pre.tt$: Force Privatization"
   decision_mym_force_privatization_desc: ""
+  decision_mym_end_force_privatization: "$mym_debug.pre.tt$: End Force Privatization"
+  decision_mym_end_force_privatization_desc: ""
   decision_mym_natalist_advertisement: "$mym_debug.pre.tt$: Advertise Natalism"
   decision_mym_natalist_advertisement_desc: "Launch a nationwide campaign extolling the joys of a large family. More cradles to fill means fewer hands at the workbench."
   decision_mym_end_natalist_advertisement: "$mym_debug.pre.tt$: End Natalist Advertising"


### PR DESCRIPTION
## Revision für Force Privatization

Der `modifier_force_privatization` wird nicht mehr zeitlich begrenzt vergeben und kann jetzt über ein Toggle-Konzept wieder entfernt werden.

### Änderungen

- **Modifier nicht mehr timed** — `months = 3` wurde aus `decision_mym_force_privatization` entfernt. Der Modifier bleibt dauerhaft aktiv, bis er aktiv entfernt wird.
- **Neue Decision `decision_mym_end_force_privatization`** — entfernt den Modifier wieder (`remove_modifier`).
- **Toggle / nur eine Decision sichtbar** — die `is_shown`-Bedingungen schließen sich gegenseitig aus:
  - Aktivieren wird gezeigt, wenn der Modifier *nicht* vorhanden ist (und kein Laissez-faire).
  - Beenden wird gezeigt, wenn der Modifier vorhanden ist.

  Dadurch ist nie beides gleichzeitig sichtbar. Gleiches Muster wie beim bestehenden „Natalist Advertisement"-Toggle.
- **Lokalisierung** — `decision_mym_end_force_privatization` (+ `_desc`) in `mym_decisions_l_english.yml` ergänzt.

### Hinweis

Bei aktivem Laissez-faire-Gesetz *und* inaktivem Modifier ist (wie schon vorher) keine der beiden Decisions sichtbar. Das verletzt die „nie beide gleichzeitig"-Regel nicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SdyFARuwPV98Do1o3KpX1

---
_Generated by [Claude Code](https://claude.ai/code/session_017SdyFARuwPV98Do1o3KpX1)_