### PR TITLE
Split theocratic country names by religious heritage

### DIFF
--- a/common/dynamic_country_names/mym_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mym_dynamic_country_names.txt
@@ -23,10 +23,23 @@
 # dyn_c_bananada keeps priority 200 on purpose: a deliberate flavour override for a
 # banana-republic Canada (the one place MyM intentionally beats the vanilla name).
 #
+# Confessional theocracy names (law_theocracy, no voting franchise) are split by the religion's
+# heritage. Each is mutually exclusive - a country has one religion, hence one heritage - so the
+# relative order among them is irrelevant; they only all need to sit BEFORE theocracy_generic:
+#   theocracy_christian    heritage_christian     "$ADJECTIVE$ Hierocracy"
+#   theocracy_islamic      heritage_islamic       "$ADJECTIVE$ Khalifate"
+#   theocracy_jewish       heritage_jewish        "$ADJECTIVE$ Kohanate"
+#   theocracy_dharmic      heritage_dharmic       "$ADJECTIVE$ Dharmarajya"   (Buddhist/Hindu/Sikh)
+#   theocracy_taoic        heritage_taoic         "$ADJECTIVE$ Celestial State" (Confucian/Shinto)
+#   theocracy_indigenous   heritage_indigenous    "$ADJECTIVE$ Shamanate"      (animist)
+#   theocracy_materialist  heritage_materialist   "$ADJECTIVE$ Cult of Reason" (atheist)
+# When the Israel Expanded mod is present, its own higher-priority Jewish theocracy name
+# overrides theocracy_jewish below.
+#
 # Gap-filler entries (also priority 0, slotted by specificity like the rest):
-#   theocracy_generic - theocracy w/o franchise that is not Christian/Muslim (and, when the
-#                       Israel Expanded mod is present, not Jewish either - that name lives there)
-#                       (sits after the confessional theocracy names)
+#   theocracy_generic - theocracy w/o franchise whose religion's heritage is none of the seven
+#                       confessional ones above (e.g. a modded religion with a novel/blank
+#                       heritage); sits after the confessional theocracy names
 #   dictatorship      - autocratic presidential/parliamentary/corporate state, after the
 #                       junta/high_command/islamic_republic/fascist_state names had their say
 #   oligarchy         - oligarchic presidential/parliamentary/corporate state, same slot
@@ -55,7 +68,9 @@ INJECT:DEFAULT = {
 
 		trigger = {
 			scope:actor ?= {
-				is_christian = yes
+				religion = {
+					has_discrimination_trait = heritage_christian
+				}
 				has_law_or_variant = law_type:law_theocracy
 				country_has_voting_franchise = no
 			}
@@ -72,6 +87,91 @@ INJECT:DEFAULT = {
 			scope:actor ?= {
 				religion = {
 					has_discrimination_trait = heritage_islamic
+				}
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_theocracy_jewish
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				religion = {
+					has_discrimination_trait = heritage_jewish
+				}
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_theocracy_dharmic
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				religion = {
+					has_discrimination_trait = heritage_dharmic
+				}
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_theocracy_taoic
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				religion = {
+					has_discrimination_trait = heritage_taoic
+				}
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_theocracy_indigenous
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				religion = {
+					has_discrimination_trait = heritage_indigenous
+				}
+				has_law_or_variant = law_type:law_theocracy
+				country_has_voting_franchise = no
+			}
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_theocracy_materialist
+		adjective = root_adj
+
+		is_main_tag_only = yes
+		priority = 0
+
+		trigger = {
+			scope:actor ?= {
+				religion = {
+					has_discrimination_trait = heritage_materialist
 				}
 				has_law_or_variant = law_type:law_theocracy
 				country_has_voting_franchise = no

--- a/localization/english/mym_dynamic_country_names_l_english.yml
+++ b/localization/english/mym_dynamic_country_names_l_english.yml
@@ -16,6 +16,11 @@
   dyn_c_zhuz: "$ADJECTIVE$ Zhuz"
   dyn_c_theocracy_christian: "$ADJECTIVE$ Hierocracy"
   dyn_c_theocracy_islamic: "$ADJECTIVE$ Khalifate"
+  dyn_c_theocracy_jewish: "$ADJECTIVE$ Kohanate"
+  dyn_c_theocracy_dharmic: "$ADJECTIVE$ Dharmarajya"
+  dyn_c_theocracy_taoic: "$ADJECTIVE$ Celestial State"
+  dyn_c_theocracy_indigenous: "$ADJECTIVE$ Shamanate"
+  dyn_c_theocracy_materialist: "$ADJECTIVE$ Cult of Reason"
   dyn_c_theocracy_generic: "$ADJECTIVE$ Theocracy"
   dyn_c_theocracy_voting: "Holy $ADJECTIVE$ Republic"
 


### PR DESCRIPTION
## Summary

Expands the autocratic theocracy dynamic country names (`law_theocracy`, no voting franchise) so that **every religious heritage** gets a distinct, period-evocative state form instead of falling through to the generic "Theocracy".

Previously only **Christian** (`Hierocracy`) and **Islamic** (`Khalifate`) theocracies had dedicated names; all other faiths read as the plain `$ADJECTIVE$ Theocracy`. Now all seven religious heritages in the game are covered:

| Heritage | Religions | Name |
|---|---|---|
| `heritage_christian` | Catholic / Protestant / Orthodox / Oriental Orthodox | `$ADJECTIVE$ Hierocracy` *(existing)* |
| `heritage_islamic` | Sunni / Shiite / Ibadi | `$ADJECTIVE$ Khalifate` *(existing)* |
| `heritage_jewish` | Jewish | **`$ADJECTIVE$ Kohanate`** |
| `heritage_dharmic` | Mahayana / Gelugpa / Theravada / Hindu / Sikh | **`$ADJECTIVE$ Dharmarajya`** |
| `heritage_taoic` | Confucian / Shinto | **`$ADJECTIVE$ Celestial State`** |
| `heritage_indigenous` | Animist | **`$ADJECTIVE$ Shamanate`** |
| `heritage_materialist` | Atheist | **`$ADJECTIVE$ Cult of Reason`** |

## Design notes

- **Uniform heritage primitive:** the existing Christian entry tested `is_christian = yes`; it now tests `religion = { has_discrimination_trait = heritage_christian }` like the Islamic entry, so the whole confessional block keys off the same "religious heritage" trait.
- **Ordering / priority:** all entries stay at `priority = 0`. The new ones are mutually exclusive (one religion → one heritage), so their relative order is irrelevant; they only need to sit **before** `theocracy_generic`, which is now a true fallback for modded religions with a novel/blank heritage.
- **Israel Expanded:** `theocracy_jewish` stays at priority 0, so that mod's own higher-priority Jewish theocracy name still overrides it. Documented inline.
- **Unchanged:** `theocracy_voting` (`Holy $ADJECTIVE$ Republic`, theocracy *with* a voting franchise) and `theocracy_generic` keep their behaviour.

## Validation

- Brace balance: 0 (balanced); 23 total dynamic name entries (+5).
- Every `name = dyn_c_theocracy_*` has a matching localization key.
- Both files retain their UTF-8 BOM; script uses tab-only indentation.

## Files

- `common/dynamic_country_names/mym_dynamic_country_names.txt`
- `localization/english/mym_dynamic_country_names_l_english.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxDHGXpupYBDasTNRirzXR)_