### PR TITLE
Rename oligarchic republics to "Patrician Republic"

### DIFF
--- a/localization/english/mym_government_l_english.yml
+++ b/localization/english/mym_government_l_english.yml
@@ -31,9 +31,13 @@
   gov_mym_vice_regency: "Vice-Regency"
   gov_mym_vice_regency_desc: "A [concept_government_type] where the throne of a [concept_puppet] monarchy stands vacant. A [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_REGENT$')] carries on the government in the name of a monarch unable to take the throne — and, above them, in the name of the [concept_overlord], at whose pleasure the regency is suffered to continue.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
 
-# Patrician Republic (renamed from vanilla "Oligarchic Republic" — Brazilian República Velha)
-  gov_brazil_oligarchic_republic_presidential: "Patrician Republic"
-  gov_brazil_oligarchic_republic_presidential_desc: "A [concept_government_type] where the [concept_country] is ruled by a [Concept('concept_ruler','$RULER_TITLE_PRESIDENT$')] [Concept('concept_election','$concept_elected$')] by a narrow patriciate of landed notables, whose estates and ancient names furnish the republic its electors and its officeholders alike.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
+# Patrician Republic — presidential/parliamentary republic governed under the Oligarchy distribution-of-power law
+# (overrides vanilla "Presidential Oligarchy" and "Oligarchy")
+  gov_presidential_oligarchy: "Patrician Republic"
+  gov_presidential_oligarchy_desc: "A [concept_government_type] where the [concept_country] is governed by its [Concept('concept_ruler','$RULER_TITLE_PRESIDENT$')] on behalf of a narrow patriciate of propertied notables. There is no popular franchise; office and influence pass among the same handful of great families and their clients.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
+
+  gov_parliamentary_oligarchy: "Patrician Republic"
+  gov_parliamentary_oligarchy_desc: "A [concept_government_type] where the [concept_country] is governed by a [Concept('concept_ruler','$RULER_TITLE_CHANCELLOR$')] answerable to an assembly drawn from a narrow patriciate of propertied notables. There is no popular franchise; office and influence pass among the same handful of great families and their clients.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
 
 ### RULER TITLE ###
   RULER_TITLE_MYM_LORD_COMMANDER: "Lord Commander"

--- a/localization/english/mym_government_l_english.yml
+++ b/localization/english/mym_government_l_english.yml
@@ -31,6 +31,10 @@
   gov_mym_vice_regency: "Vice-Regency"
   gov_mym_vice_regency_desc: "A [concept_government_type] where the throne of a [concept_puppet] monarchy stands vacant. A [Concept('concept_ruler','$RULER_TITLE_MYM_VICE_REGENT$')] carries on the government in the name of a monarch unable to take the throne — and, above them, in the name of the [concept_overlord], at whose pleasure the regency is suffered to continue.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
 
+# Patrician Republic (renamed from vanilla "Oligarchic Republic" — Brazilian República Velha)
+  gov_brazil_oligarchic_republic_presidential: "Patrician Republic"
+  gov_brazil_oligarchic_republic_presidential_desc: "A [concept_government_type] where the [concept_country] is ruled by a [Concept('concept_ruler','$RULER_TITLE_PRESIDENT$')] [Concept('concept_election','$concept_elected$')] by a narrow patriciate of landed notables, whose estates and ancient names furnish the republic its electors and its officeholders alike.\n\n$TRANSFER_OF_POWER_NAME_DESC$"
+
 ### RULER TITLE ###
   RULER_TITLE_MYM_LORD_COMMANDER: "Lord Commander"
   RULER_TITLE_MYM_LORD_REGENT: "Lord Regent"


### PR DESCRIPTION
## Summary

Renames the oligarchic republic government types to **Patrician Republic**, scoped to the **Oligarchy** distribution-of-power law combined with a **presidential or parliamentary republic**.

This is a localization-only override — no vanilla files, government-type definitions, or selection logic are touched.

## Changes

`localization/english/mym_government_l_english.yml`:

| Government type | Condition | New name |
|---|---|---|
| `gov_presidential_oligarchy` | Presidential Republic + Oligarchy (DOP) | **Patrician Republic** |
| `gov_parliamentary_oligarchy` | Parliamentary Republic + Oligarchy (DOP) | **Patrician Republic** |

Both also get a matching patrician-themed description.

## Notes

- These two keys map exactly to the requested combination: autocracy is caught earlier by `gov_presidential_dictatorship` / `gov_parliamentary_dictatorship` (which explicitly require `law_autocracy`), so the franchise-less, non-autocratic case left for `*_oligarchy` is precisely `law_oligarchy`.
- Brazil's `gov_brazil_oligarchic_republic_presidential` (República Velha, Landed Voting) is intentionally **not** affected and keeps its vanilla "Oligarchic Republic" name.
- Heavily flavoured special cases (`gov_junta`, `gov_banana_republic`, `gov_francocracia`, …) keep their own names by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvpNsgYRstR7incagcXuN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvpNsgYRstR7incagcXuN2)_