### PR TITLE
Simplify republic dynamic country names

### DIFF
--- a/common/dynamic_country_names/mym_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mym_dynamic_country_names.txt
@@ -35,9 +35,6 @@
 #                       heritage); sits after the confessional theocracy names
 #   dictatorship      - autocratic presidential/parliamentary/corporate state, after the
 #                       junta/high_command/islamic_republic/fascist_state names had their say
-#   oligarchy         - oligarchic presidential/parliamentary/corporate state, same slot;
-#                       reads as the plain "$ADJECTIVE$ Republic", but oligarchies lack a voting
-#                       franchise so they miss dyn_c_republic - this entry maps them onto it
 # Monarchies and social monarchies are intentionally left to their base / vanilla names.
 INJECT:DEFAULT = {
 	dynamic_country_name = {
@@ -380,24 +377,6 @@ INJECT:DEFAULT = {
 					has_law_or_variant = law_type:law_corporate_state
 				}
 				has_law_or_variant = law_type:law_autocracy
-			}
-		}
-	}
-	dynamic_country_name = {
-		name = dyn_c_oligarchy
-		adjective = root_adj
-
-		is_main_tag_only = yes
-		priority = 0
-
-		trigger = {
-			scope:actor ?= {
-				OR = {
-					has_law_or_variant = law_type:law_presidential_republic
-					has_law_or_variant = law_type:law_parliamentary_republic
-					has_law_or_variant = law_type:law_corporate_state
-				}
-				has_law_or_variant = law_type:law_oligarchy
 			}
 		}
 	}

--- a/common/dynamic_country_names/mym_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mym_dynamic_country_names.txt
@@ -35,7 +35,9 @@
 #                       heritage); sits after the confessional theocracy names
 #   dictatorship      - autocratic presidential/parliamentary/corporate state, after the
 #                       junta/high_command/islamic_republic/fascist_state names had their say
-#   oligarchy         - oligarchic presidential/parliamentary/corporate state, same slot
+#   oligarchy         - oligarchic presidential/parliamentary/corporate state, same slot;
+#                       reads as the plain "$ADJECTIVE$ Republic", but oligarchies lack a voting
+#                       franchise so they miss dyn_c_republic - this entry maps them onto it
 # Monarchies and social monarchies are intentionally left to their base / vanilla names.
 INJECT:DEFAULT = {
 	dynamic_country_name = {

--- a/common/dynamic_country_names/mym_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mym_dynamic_country_names.txt
@@ -11,14 +11,7 @@
 # ordered from most to least specific to reproduce the original precedence:
 #   theocracy_* / anarchic                                             (were priority 3)
 #   junta / high_command / zhuz / islamic_republic                     (were priority 2)
-#   communist_* / fascist_state / parliamentary_republic / republic / technocracy (were priority 1)
-#
-# parliamentary_republic is a MyM-original flavour name (not a vanilla re-implementation). It
-# specialises the generic dyn_c_republic and sits directly before it so that ONLY parliamentary
-# republics read as "$ADJECTIVE$ Federal Republic", while presidential republics (and the other
-# franchise forms, e.g. corporate state, chiefdom) keep the plain "$ADJECTIVE$ Republic". It
-# requires a voting franchise (matching dyn_c_republic) and excludes USA/CSA so their iconic base
-# names survive. Any higher-priority vanilla name (e.g. dyn_c_french_republic) still wins.
+#   communist_* / fascist_state / republic / technocracy             (were priority 1)
 #
 # dyn_c_bananada keeps priority 200 on purpose: a deliberate flavour override for a
 # banana-republic Canada (the one place MyM intentionally beats the vanilla name).
@@ -403,24 +396,6 @@ INJECT:DEFAULT = {
 					has_law_or_variant = law_type:law_corporate_state
 				}
 				has_law_or_variant = law_type:law_oligarchy
-			}
-		}
-	}
-	dynamic_country_name = {
-		name = dyn_c_parliamentary_republic
-		adjective = root_adj
-
-		is_main_tag_only = yes
-		priority = 0
-
-		trigger = {
-			scope:actor ?= {
-				NOR = {
-					c:USA ?= this
-					c:CSA ?= this
-				}
-				has_law_or_variant = law_type:law_parliamentary_republic
-				country_has_voting_franchise = yes
 			}
 		}
 	}

--- a/localization/english/mym_dynamic_country_names_l_english.yml
+++ b/localization/english/mym_dynamic_country_names_l_english.yml
@@ -8,7 +8,7 @@
   dyn_c_islamic_republic: "$ADJECTIVE$ Islamic Republic"
   dyn_c_technocracy: "$ADJECTIVE$ Directorate"
   dyn_c_dictatorship: "$ADJECTIVE$ National Republic"
-  dyn_c_oligarchy: "$ADJECTIVE$ Oligarchic Republic"
+  dyn_c_oligarchy: "$ADJECTIVE$ Republic"
   dyn_c_anarchic: "$ADJECTIVE$ Communes"
   dyn_c_junta: "$ADJECTIVE$ Junta"
   dyn_c_high_command: "$ADJECTIVE$ High Command"

--- a/localization/english/mym_dynamic_country_names_l_english.yml
+++ b/localization/english/mym_dynamic_country_names_l_english.yml
@@ -4,7 +4,6 @@
   dyn_c_communist_autocracy: "Democratic Republic of $NAME$"
   dyn_c_communist_democracy: "$ADJECTIVE$ People's Republic"
   dyn_c_fascist_state: "$ADJECTIVE$ State "
-  dyn_c_parliamentary_republic: "$ADJECTIVE$ Federal Republic"
   dyn_c_republic: "$ADJECTIVE$ Republic"
   dyn_c_islamic_republic: "$ADJECTIVE$ Islamic Republic"
   dyn_c_technocracy: "$ADJECTIVE$ Directorate"

--- a/localization/english/mym_dynamic_country_names_l_english.yml
+++ b/localization/english/mym_dynamic_country_names_l_english.yml
@@ -8,7 +8,6 @@
   dyn_c_islamic_republic: "$ADJECTIVE$ Islamic Republic"
   dyn_c_technocracy: "$ADJECTIVE$ Directorate"
   dyn_c_dictatorship: "$ADJECTIVE$ National Republic"
-  dyn_c_oligarchy: "$ADJECTIVE$ Republic"
   dyn_c_anarchic: "$ADJECTIVE$ Communes"
   dyn_c_junta: "$ADJECTIVE$ Junta"
   dyn_c_high_command: "$ADJECTIVE$ High Command"


### PR DESCRIPTION
## What changed

Two republic variants that previously carried a distinct dynamic country name are simplified:

- **Parliamentary republics** — removed the dedicated `dyn_c_parliamentary_republic` entry (was "<Adj> Federal Republic"). They now fall through to the generic `dyn_c_republic` and read as plain **"<Adj> Republic"**, exactly like presidential republics. This reverts to the state before the presidential/parliamentary name split.
- **Oligarchic republics** — removed the `dyn_c_oligarchy` entry (was "<Adj> Oligarchic Republic") entirely. Oligarchic presidential/parliamentary/corporate-state republics no longer get a dedicated dynamic country name; since oligarchies have no voting franchise they also don't match `dyn_c_republic`, so they fall back to their **base / vanilla country name**.

## Notes

- Government-type labels are untouched: oligarchic republics still show **"Patrician Republic"** as their government type (`gov_presidential_oligarchy` / `gov_parliamentary_oligarchy`) — that is a separate system from the dynamic country name.
- Header comments in the dynamic-names file were updated to match the current behavior; both files keep their UTF-8 BOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114M7CU2oTgQdQrztLB6DuM