### PR TITLE
Guard ruler scope-changes against missing rulers

### DIFF
--- a/common/dynamic_country_names/mym_dynamic_country_names.txt
+++ b/common/dynamic_country_names/mym_dynamic_country_names.txt
@@ -219,7 +219,7 @@ INJECT:DEFAULT = {
 					has_law_or_variant = law_type:law_mass_conscription
 					has_law_or_variant = law_type:law_professional_army
 				}
-				ruler = {
+				ruler ?= {
 					has_role_of_type = general
 					is_interest_group_type = ig_armed_forces
 				}
@@ -245,7 +245,7 @@ INJECT:DEFAULT = {
 					has_law_or_variant = law_type:law_mass_conscription
 					has_law_or_variant = law_type:law_professional_army
 				}
-				ruler = {
+				ruler ?= {
 					has_role_of_type = general
 					is_interest_group_type = ig_armed_forces
 				}

--- a/events/character_events/mym_corleone_events.txt
+++ b/events/character_events/mym_corleone_events.txt
@@ -39,7 +39,7 @@ corleone.2 = { # New York Daily Chronicle, November 2, 1922
 
 	immediate = {
 		set_global_variable = corleone_2_done_globvar
-		ruler = { save_scope_as = ruler_scope }
+		ruler ?= { save_scope_as = ruler_scope }
 	}
 
 	option = {
@@ -64,7 +64,7 @@ corleone.3 = { # New York Daily Chronicle, June 6, 1934
 
 	immediate = {
 		set_global_variable = corleone_3_done_globvar
-		ruler = { save_scope_as = ruler_scope }
+		ruler ?= { save_scope_as = ruler_scope }
 	}
 
 	option = {

--- a/events/mym_debug_events.txt
+++ b/events/mym_debug_events.txt
@@ -390,7 +390,7 @@ mym_debug.4 = {
 
 		trigger = {
 			exists = ideology:ideology_anarcho_libertarian
-			ruler = {
+			ruler ?= {
 				NOT = { has_ideology = ideology:ideology_anarcho_libertarian }
 			}
 		}
@@ -408,7 +408,7 @@ mym_debug.4 = {
 
 		trigger = {
 			exists = ideology:ideology_anti_statist
-			ruler = {
+			ruler ?= {
 				NOT = { has_ideology = ideology:ideology_anti_statist }
 			}
 		}
@@ -426,7 +426,7 @@ mym_debug.4 = {
 
 		trigger = {
 			exists = ideology:ideology_anti_feminist
-			ruler = {
+			ruler ?= {
 				NOT = { has_ideology = ideology:ideology_anti_feminist }
 			}
 		}
@@ -444,7 +444,7 @@ mym_debug.4 = {
 
 		trigger = {
 			exists = ideology:ideology_secular_humanitarian
-			ruler = {
+			ruler ?= {
 				NOT = { has_ideology = ideology:ideology_secular_humanitarian }
 			}
 		}
@@ -462,7 +462,7 @@ mym_debug.4 = {
 
 		trigger = {
 			exists = ideology:ideology_libertarian_utopian
-			ruler = {
+			ruler ?= {
 				NOT = { has_ideology = ideology:ideology_libertarian_utopian }
 			}
 		}

--- a/events/mym_enact_the_act_events.txt
+++ b/events/mym_enact_the_act_events.txt
@@ -20,7 +20,7 @@ enact_the_act.1 = {
 	trigger = {} # Triggered by decision_mym_enact_the_act
 
 	immediate = {
-		ruler = { save_scope_as = ruler_scope }
+		ruler ?= { save_scope_as = ruler_scope }
 	}
 
 	# Sign the Act — pass law_autocracy


### PR DESCRIPTION
## What

Guards every `ruler` scope-change evaluated where a country may have no ruler, eliminating the `Event target link 'ruler' returned an invalid object` log spam.

## Reported fix

- **`dyn_c_junta` and `dyn_c_high_command`** (`mym_dynamic_country_names.txt`): convert the unguarded `ruler = { has_role_of_type = general … }` to `ruler ?= { … }`. These dynamic country-name triggers run for every country on every evaluation, so a ruler-less country emitted the error continuously.

## Same-class hardening

- **`corleone.2` / `corleone.3` / `enact_the_act.1` immediates**: align the `ruler = { save_scope_as = ruler_scope }` with the project's existing `ruler ?= { save_scope_as = ruler_scope }` idiom, so a ruler-less country no longer errors on the save-scope.
- **`mym_debug.4`**: the five "make an agitator the ruler" option triggers converted to `ruler ?= { … }`.

## Why it's safe

`ruler ?= { … }` means "ruler exists **and** …", preserving the boolean result for any country that has a ruler and resolving to `false` (no error) when none exists. UTF-8 BOM preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S78yebt9FxLcyBCanPJNXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01S78yebt9FxLcyBCanPJNXY)_