### PR TITLE
Add bottom-two-percent purge cheat to the debug menu

### DIFF
--- a/common/scripted_effects/mym_scripted_effects.txt
+++ b/common/scripted_effects/mym_scripted_effects.txt
@@ -132,6 +132,110 @@ mym_cheat_spread_building_levels = {
 	remove_variable = mym_cheat_spread_counter_var
 }
 
+# Purges the "bottom two percent" (mym_debug.3): captures and kills every
+# unemployed pop that sits in the intersection of the country's bottom-2%
+# population band by literacy and its bottom-2% band by standard of living.
+# Being an intersection, at most 2% of the population dies.
+#
+# Both bands are true population-weighted percentiles: a threshold is raised
+# step by step until the pops below it cover at least 2% of total_population.
+# Pops are chunky, so the band can overshoot slightly - the pop that crosses
+# the 2% line is included whole.
+#
+# The kill runs per state and culture through kill_population_in_state,
+# because kill effects only exist on country/state scope, never on pop scope
+# (see dsr_state_effects.txt in DonSantanian Resources). The engine spreads
+# those deaths across every pop of that culture in the state, so employed
+# pops of the same culture catch part of the volley meant for the target
+# group. The head count is exact; the individual victims are approximate.
+mym_cheat_purge_bottom_two_percent = {
+	# Band size both percentile searches aim for: 2% of the population
+	set_variable = {
+		name = mym_purge_band_var
+		value = {
+			value = total_population
+			multiply = 0.02
+		}
+	}
+
+	# Literacy percentile: raise the threshold in 1pp steps until the pops
+	# below it cover the band. Literacy is 0..1, so 100 steps at most.
+	set_variable = { name = mym_purge_lit_thr_var value = 0 }
+	set_variable = { name = mym_purge_cum_var value = 0 }
+	while = {
+		limit = {
+			var:mym_purge_cum_var < var:mym_purge_band_var
+			var:mym_purge_lit_thr_var < 1
+		}
+		change_variable = { name = mym_purge_lit_thr_var add = 0.01 }
+		set_variable = { name = mym_purge_cum_var value = 0 }
+		every_scope_pop = {
+			limit = { literacy_rate < ROOT.var:mym_purge_lit_thr_var }
+			ROOT = {
+				change_variable = { name = mym_purge_cum_var add = prev.total_size }
+			}
+		}
+	}
+
+	# Standard of living percentile: same search on the 0..99 wellbeing
+	# scale, so the step is a whole point.
+	set_variable = { name = mym_purge_sol_thr_var value = 0 }
+	set_variable = { name = mym_purge_cum_var value = 0 }
+	while = {
+		limit = {
+			var:mym_purge_cum_var < var:mym_purge_band_var
+			var:mym_purge_sol_thr_var < 99
+		}
+		change_variable = { name = mym_purge_sol_thr_var add = 1 }
+		set_variable = { name = mym_purge_cum_var value = 0 }
+		every_scope_pop = {
+			limit = { standard_of_living < ROOT.var:mym_purge_sol_thr_var }
+			ROOT = {
+				change_variable = { name = mym_purge_cum_var add = prev.total_size }
+			}
+		}
+	}
+
+	# The purge: per state and culture, count the target pops and kill
+	# exactly that many people of that culture in that state.
+	every_scope_state = {
+		limit = {
+			any_scope_pop = { mym_pop_is_purge_target = yes }
+		}
+		every_scope_culture = {
+			save_temporary_scope_as = mym_purge_culture
+			prev = {
+				ROOT = {
+					set_variable = { name = mym_purge_kill_var value = 0 }
+				}
+				every_scope_pop = {
+					limit = {
+						culture = scope:mym_purge_culture
+						mym_pop_is_purge_target = yes
+					}
+					ROOT = {
+						change_variable = { name = mym_purge_kill_var add = prev.total_size }
+					}
+				}
+				if = {
+					limit = { ROOT.var:mym_purge_kill_var > 0 }
+					kill_population_in_state = {
+						value = ROOT.var:mym_purge_kill_var
+						culture = scope:mym_purge_culture
+					}
+				}
+			}
+		}
+	}
+
+	# Leave no scratch state behind
+	remove_variable = mym_purge_band_var
+	remove_variable = mym_purge_cum_var
+	remove_variable = mym_purge_lit_thr_var
+	remove_variable = mym_purge_sol_thr_var
+	remove_variable = mym_purge_kill_var
+}
+
 # Creates a 25-year bilateral pact between the two Baltic successor states
 # $FIRST$ and $SECOND$ (tags such as LIT / LAT / EST) and maxes out their
 # mutual opinion. baltic_dissolution.1 calls this once per surviving pair,

--- a/common/scripted_triggers/mym_scripted_triggers.txt
+++ b/common/scripted_triggers/mym_scripted_triggers.txt
@@ -63,3 +63,14 @@ at_least_one_politician_is_no_anarchist = {
 		}
 	}
 }
+
+# Pop belongs to the "bottom two percent" purge target group (mym_debug.3):
+# unemployed AND inside the country's bottom-2% population band by literacy
+# AND inside the bottom-2% band by standard of living. Only meaningful while
+# mym_cheat_purge_bottom_two_percent has its threshold variables set on ROOT
+# (the purging country) - do not use it anywhere else.
+mym_pop_is_purge_target = {
+	is_employed = no
+	literacy_rate < ROOT.var:mym_purge_lit_thr_var
+	standard_of_living < ROOT.var:mym_purge_sol_thr_var
+}

--- a/events/mym_debug_events.txt
+++ b/events/mym_debug_events.txt
@@ -361,6 +361,7 @@ mym_debug.3 = {
 	# living band. Variable-gated 50 year cooldown. The percentile bands are
 	# only computed when the button is pressed, so the menu gates on the
 	# cheapest necessary condition: somebody has to be unemployed at all.
+	# Inspired by Asmongold
 	option = {
 		name = mym_debug.3.e
 

--- a/events/mym_debug_events.txt
+++ b/events/mym_debug_events.txt
@@ -355,6 +355,35 @@ mym_debug.3 = {
 			trigger_event = { id = mym_debug.3 popup = yes }
 		}
 	}
+
+	# Purges the bottom two percent: kills every unemployed pop inside both
+	# the country's bottom-2% literacy band and its bottom-2% standard of
+	# living band. Variable-gated 50 year cooldown. The percentile bands are
+	# only computed when the button is pressed, so the menu gates on the
+	# cheapest necessary condition: somebody has to be unemployed at all.
+	option = {
+		name = mym_debug.3.e
+
+		trigger = {
+			NOT = { has_variable = mym_purge_cooldown_var }
+			any_scope_state = {
+				any_scope_pop = { is_employed = no }
+			}
+		}
+
+		custom_tooltip = {
+			text = mym_debug.3.e_tt
+			mym_cheat_purge_bottom_two_percent = yes
+		}
+
+		hidden_effect = {
+			set_variable = {
+				name = mym_purge_cooldown_var
+				years = 50
+			}
+			trigger_event = { id = mym_debug.3 popup = yes }
+		}
+	}
 }
 
 # Character Spawn - promotes (or creates) an agitator of the chosen ideology

--- a/localization/english/mym_debug_contents_l_english.yml
+++ b/localization/english/mym_debug_contents_l_english.yml
@@ -38,6 +38,8 @@
   mym_debug.3.a: "All countries get era 5 tech"
   mym_debug.3.b: "All countries become independent"
   mym_debug.3.d: "Give me all the Tech, du Dreck!"
+  mym_debug.3.e: "Purge the bottom two percent"
+  mym_debug.3.e_tt: "Captures every #bold unemployed#! pop that sits in both the bottom-2% [concept_literacy] band and the bottom-2% [concept_sol] band of the population — and kills them. The two bands intersect, so at most 2% of the population dies. Deaths are dealt per state and culture, so employed pops of the same culture may catch some of the volley. Available once every #bold 50 years#!."
 
 # .4 Character Spawn
   mym_debug.4.tt: "$mym_debug.pre.tt$ Character Spawn"


### PR DESCRIPTION
## Summary
- New Game Breaker debug menu option (`mym_debug.3.e`) that kills the "bottom two percent": every unemployed pop sitting in the intersection of the country's bottom-2% population band by literacy and its bottom-2% band by standard of living
- Both bands are computed as real population-weighted percentiles at runtime via a stepped threshold search, so the target group is at most 2% of the population
- Kill is dealt per state/culture through `kill_population_in_state` (kill effects don't exist on pop scope), so employed pops of the same culture in a state may catch part of the volley — head count is exact, individual victims are approximate
- Option is gated on at least one unemployed pop existing, and on a variable-backed 50-year cooldown

## Test plan
- [ ] Verified brace balance / script syntax of all touched files
- [ ] In-game: trigger the debug menu → Game Breaker → Purge the bottom two percent, confirm pop deaths and tooltip, confirm option disappears for 50 years afterward
- [ ] In-game: check `error.log` for any issues with `kill_population_in_state` accepting a variable-derived `value`


---
_Generated by [Claude Code](https://claude.ai/code/session_01VhZKsfp6da22rA4as7hnor)_